### PR TITLE
Updated django-guardian dependency to fix test errors with Python 2.7.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     install_requires=[
         'django>=1.8,<1.9a1',
         'djangorestframework>=3.1',
-        'django-guardian==1.3',
+        'django-guardian>=1.3.1',
         'django-filter>=0.9.2',
         'django-pgjsonb>=0.0.16',
         'django-mathfilters>=0.3.0',


### PR DESCRIPTION
With Python 2.7 and django-guardian 1.3, tests on CentOS/Fedora were
failing with: "DoesNotExist: ContentType matching query does not exist."