### PR TITLE
Fixes for render_descriptor

### DIFF
--- a/resolwe/flow/models.py
+++ b/resolwe/flow/models.py
@@ -361,10 +361,11 @@ class Data(BaseModel):
     descriptor = JSONField(default={})
 
     def save(self, *args, **kwargs):
-
-        if not self.pk:  # create
+        # Generate the descriptor if one is not already set.
+        if not self.descriptor:
             render_descriptor(self)
 
+        if not self.pk:  # create
             # default values for INPUT
             for field_schema, fields, path in iterate_schema(self.input, self.process.input_schema, ''):
                 if 'default' in field_schema and field_schema['name'] not in fields:
@@ -591,6 +592,8 @@ def hydrate_input_references(input_, input_schema, hydrate_values=True):
                 # if re.match('^[0-9a-fA-F]{24}$', str(value)) is None:
                 #     print "ERROR: data:<...> value in field \"{}\", type \"{}\" not ObjectId but {}.".format(
                 #         name, field_schema['type'], value)
+                if value is None:
+                    continue
 
                 data = Data.objects.get(id=value)
                 output = data.output.copy()
@@ -610,6 +613,8 @@ def hydrate_input_references(input_, input_schema, hydrate_values=True):
                     # if re.match('^[0-9a-fA-F]{24}$', str(val)) is None:
                     #     print "ERROR: data:<...> value in {}, type \"{}\" not ObjectId but {}.".format(
                     #         name, field_schema['type'], val)
+                    if val is None:
+                        continue
 
                     data = Data.objects.get(id=val)
                     output = data.output.copy()


### PR DESCRIPTION
Since d054afc76fd00f561b1766a45797797082cc3d11 the import process from the old system (`genesis_migrate`) is completely broken (some issues are introduced by that commit and some are just exposed by it). This pull request fixes some obvious issues with the mentioned commit, but there is also another problem.

Importing a dump currently fails with the following error when calling `hydrate_input_references`:
```
ValueError: invalid literal for int() with base 10: '54f70fb6fad58d20240baf97'
```

The issue seems to be that `render_descriptor` tries to resolve the references to imported data objects, but the Data's input JSON itself is not migrated at all, so all references are wrong. The migration process should also recursively fix the references before loading objects. But since Data objects may reference each other, we need to establish a proper ordering so we can save objects without any references first and then make our way towards objects that depend on others.

Probably the best way would be to construct a dependency graph in the first phase and then use a topological sort to get a suitable order. Then save the Data objects in order, record mappings from the old identifiers to the new identifiers and update JSON fields before saving the object.