### PR TITLE
Include primary key when serializing Process

### DIFF
--- a/resolwe/flow/serializers.py
+++ b/resolwe/flow/serializers.py
@@ -69,7 +69,7 @@ class ProcessSerializer(ResolweBaseSerializer):
         """ProcessSerializer Meta options."""
         model = Process
         update_protected_fields = ('contributor', )
-        read_only_fields = ('slug', 'name', 'created', 'modified', 'version', 'type', 'category',
+        read_only_fields = ('id', 'slug', 'name', 'created', 'modified', 'version', 'type', 'category',
                             'persistence', 'description', 'input_schema', 'output_schema', 'run', )
         fields = update_protected_fields + read_only_fields
 


### PR DESCRIPTION
This is required as all API views need to provide primary keys in order for them to be usable by the query observers. For some reason, the primary key (field `id`) was not provided with Process serializer.