### PR TITLE
Fix broken migration to AutoSlugField

### DIFF
--- a/resolwe/flow/migrations/0004_autoslug_field.py
+++ b/resolwe/flow/migrations/0004_autoslug_field.py
@@ -16,31 +16,31 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='collection',
             name='slug',
-            field=autoslug.fields.AutoSlugField(editable=True, populate_from='name', unique_with=('version',)),
+            field=autoslug.fields.AutoSlugField(editable=True, populate_from='name', unique_with=('version',), max_length=100),
         ),
         migrations.AlterField(
             model_name='data',
             name='slug',
-            field=autoslug.fields.AutoSlugField(editable=True, populate_from='name', unique_with=('version',)),
+            field=autoslug.fields.AutoSlugField(editable=True, populate_from='name', unique_with=('version',), max_length=100),
         ),
         migrations.AlterField(
             model_name='descriptorschema',
             name='slug',
-            field=autoslug.fields.AutoSlugField(editable=True, populate_from='name', unique_with=('version',)),
+            field=autoslug.fields.AutoSlugField(editable=True, populate_from='name', unique_with=('version',), max_length=100),
         ),
         migrations.AlterField(
             model_name='process',
             name='slug',
-            field=autoslug.fields.AutoSlugField(editable=True, populate_from='name', unique_with=('version',)),
+            field=autoslug.fields.AutoSlugField(editable=True, populate_from='name', unique_with=('version',), max_length=100),
         ),
         migrations.AlterField(
             model_name='storage',
             name='slug',
-            field=autoslug.fields.AutoSlugField(editable=True, populate_from='name', unique_with=('version',)),
+            field=autoslug.fields.AutoSlugField(editable=True, populate_from='name', unique_with=('version',), max_length=100),
         ),
         migrations.AlterField(
             model_name='trigger',
             name='slug',
-            field=autoslug.fields.AutoSlugField(editable=True, populate_from='name', unique_with=('version',)),
+            field=autoslug.fields.AutoSlugField(editable=True, populate_from='name', unique_with=('version',), max_length=100),
         ),
     ]

--- a/resolwe/flow/models.py
+++ b/resolwe/flow/models.py
@@ -53,7 +53,7 @@ class BaseModel(models.Model):
         default_permissions = ()
 
     #: URL slug
-    slug = AutoSlugField(populate_from='name', unique_with='version', editable=True)
+    slug = AutoSlugField(populate_from='name', unique_with='version', editable=True, max_length=100)
 
     #: process version
     version = VersionField(number_bits=VERSION_NUMBER_BITS, default=0)


### PR DESCRIPTION
The previous one shrunk the `slug` field to 50 characters, while it was 100 before. This causes failures when migrating old data.