### PR TITLE
Add ability to use a custom executor command

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -5,6 +5,16 @@ Change Log
 All notable changes to this project are documented in this file.
 
 
+==========
+Unreleased
+==========
+
+Added
+-----
+- Ability to use a custom executor command by specifying the
+  ``FLOW_EXECUTOR['COMMAND']`` setting
+
+
 ==================
 1.1.0 - 2016-04-18
 ==================

--- a/resolwe/flow/executors/docker.py
+++ b/resolwe/flow/executors/docker.py
@@ -13,6 +13,7 @@ from .local import FlowExecutor as LocalFlowExecutor
 
 class FlowExecutor(LocalFlowExecutor):
     def start(self):
+        command = settings.FLOW_EXECUTOR.get('COMMAND', 'docker')
         container_image = settings.FLOW_EXECUTOR['CONTAINER_IMAGE']
 
         if self.data_id != 'no_data_id':
@@ -38,8 +39,8 @@ class FlowExecutor(LocalFlowExecutor):
         # a login Bash shell is needed to source ~/.bash_profile
         self.proc = subprocess.Popen(
             shlex.split(
-                'docker run --rm --interactive --name={} {} {} /bin/bash --login'.format(
-                    container_name, volumes, container_image)),
+                '{} run --rm --interactive --name={} {} {} /bin/bash --login'.format(
+                    command, container_name, volumes, container_image)),
             stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True)
 
         self.stdout = self.proc.stdout

--- a/resolwe/flow/executors/local.py
+++ b/resolwe/flow/executors/local.py
@@ -3,8 +3,11 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 import os
+import shlex
 import subprocess
 import time
+
+from django.conf import settings
 
 from resolwe.flow.executors import BaseFlowExecutor
 
@@ -21,7 +24,8 @@ class FlowExecutor(BaseFlowExecutor):
         self.kill_delay = 5
 
     def start(self):
-        self.proc = subprocess.Popen(['/bin/bash'],
+        command = settings.FLOW_EXECUTOR.get('COMMAND', '/bin/bash')
+        self.proc = subprocess.Popen(shlex.split(command),
                                      stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                                      stderr=subprocess.STDOUT, universal_newlines=True)
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -105,6 +105,9 @@ FLOW_EXECUTOR = {
     'DATA_PATH': os.path.join(PROJECT_ROOT, '.data'),
     'UPLOAD_PATH': os.path.join(PROJECT_ROOT, '.upload'),
 }
+# Set custom executor command if set via environment variable
+if 'RESOLWE_EXECUTOR_COMMAND' in os.environ:
+    FLOW_EXECUTOR['COMMAND'] = os.environ['RESOLWE_EXECUTOR_COMMAND']
 FLOW_API = {
     'PERMISSIONS': 'resolwe.permissions.genesis',
 }


### PR DESCRIPTION
Use it by specifying the `FLOW_EXECUTOR['COMMAND']` setting.
Change test project's settings to allow setting a custom executor command via `RESOLWE_EXECUTOR_COMMAND` environment variable.