### PR TITLE
Rename assertFileExist to assertFileExists

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -9,6 +9,10 @@ All notable changes to this project are documented in this file.
 Unreleased
 ==========
 
+Changed
+-------
+- Rename assertFileExist to assertFileExists
+
 Added
 -----
 - Ability to use a custom executor command by specifying the

--- a/resolwe/flow/tests/__init__.py
+++ b/resolwe/flow/tests/__init__.py
@@ -331,7 +331,7 @@ class ProcessTestCase(TestCase):
                          msg="File contents hash mismatch: {} != {}".format(
                              wanted_hash, output_hash) + self._debug_info(obj))
 
-    def assertFileExist(self, obj, field_path):  # pylint: disable=invalid-name
+    def assertFileExists(self, obj, field_path):  # pylint: disable=invalid-name
         """Compare output file of a processor to the given correct file.
 
         :param obj: Data object which includes file that we want to


### PR DESCRIPTION
The `assertFileExists` function is [already used by downstream project Resolwe Bioinformatics](https://github.com/genialis/resolwe-bio/search?utf8=%E2%9C%93&q=assertFileExists).

The old function (`assertFileExist`) was [not used by Resolwe project](https://github.com/genialis/resolwe/search?utf8=%E2%9C%93&q=assertFileExist) or [Resolwe Bioinformatics project](https://github.com/genialis/resolwe-bio/search?utf8=%E2%9C%93&q=assertFileExist)