### PR TITLE
Use FLOW_EXECUTOR['COMMAND'] everywhere

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -27,6 +27,7 @@ Fixed
 - Render data name again after inputs are resolved
 - Ensure Tox installs the package from sdist
 - Pass all Resolwe's environment variables to Tox's testing environment
+- Ensure tests gracefully handle unavailability of Docker
 
 
 ==================

--- a/resolwe/flow/executors/docker.py
+++ b/resolwe/flow/executors/docker.py
@@ -12,8 +12,12 @@ from .local import FlowExecutor as LocalFlowExecutor
 
 
 class FlowExecutor(LocalFlowExecutor):
+
+    def __init__(self, *args, **kwargs):
+        super(FlowExecutor, self).__init__(*args, **kwargs)
+        self.command = settings.FLOW_EXECUTOR.get('COMMAND', 'docker')
+
     def start(self):
-        command = settings.FLOW_EXECUTOR.get('COMMAND', 'docker')
         container_image = settings.FLOW_EXECUTOR['CONTAINER_IMAGE']
 
         if self.data_id != 'no_data_id':
@@ -40,7 +44,7 @@ class FlowExecutor(LocalFlowExecutor):
         self.proc = subprocess.Popen(
             shlex.split(
                 '{} run --rm --interactive --name={} {} {} /bin/bash --login'.format(
-                    command, container_name, volumes, container_image)),
+                    self.command, container_name, volumes, container_image)),
             stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True)
 
         self.stdout = self.proc.stdout
@@ -61,4 +65,4 @@ class FlowExecutor(LocalFlowExecutor):
         return self.proc.returncode
 
     def terminate(self, data_id):
-        subprocess.call(shlex.split('docker rm -f {}').format(str(data_id)))
+        subprocess.call(shlex.split('{} rm -f {}').format(self.command, str(data_id)))

--- a/resolwe/flow/executors/local.py
+++ b/resolwe/flow/executors/local.py
@@ -19,13 +19,14 @@ class FlowExecutor(BaseFlowExecutor):
 
     """Local dataflow executor proxy."""
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
+        super(FlowExecutor, self).__init__(*args, **kwargs)
+        self.command = settings.FLOW_EXECUTOR.get('COMMAND', '/bin/bash')
         self.processes = {}
         self.kill_delay = 5
 
     def start(self):
-        command = settings.FLOW_EXECUTOR.get('COMMAND', '/bin/bash')
-        self.proc = subprocess.Popen(shlex.split(command),
+        self.proc = subprocess.Popen(shlex.split(self.command),
                                      stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                                      stderr=subprocess.STDOUT, universal_newlines=True)
 

--- a/resolwe/flow/tests/test_executors.py
+++ b/resolwe/flow/tests/test_executors.py
@@ -18,7 +18,8 @@ except ImportError:
 
 
 def check_docker():
-    return subprocess.call(shlex.split('docker info'), stdout=subprocess.PIPE) == 1
+    command = settings.FLOW_EXECUTOR.get('COMMAND', 'docker')
+    return subprocess.call(shlex.split(command + ' info'), stdout=subprocess.PIPE) == 1
 
 
 class DockerExecutorTestCase(unittest.TestCase):


### PR DESCRIPTION
Improve handling of the case when Docker is not available.