### PR TITLE
Ensure a recent pip is installed when Tox creates a new virtualenv

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -15,6 +15,10 @@ Changed
    model and make it its parent
  - Remove all logic for handling ``flow_collection``
 
+Fixed
+-----
+- Ensure a recent pip is installed when Tox creates a new virtual environment
+
 
 ==================
 1.2.0 - 2016-05-06

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,9 @@ envlist = py27,py34,py35
 skip_missing_interpreters = True
 
 [testenv]
+deps =
+# make sure a recent pip is installed
+    pip>=7.0.0
 commands =
 # install documentation and testing requirements
 # NOTE: Don't use 'deps = .[docs,test]' tox option since we want Tox to install


### PR DESCRIPTION
This fixes a problem with installing Resolwe in a new virtualenv on CentOS 7.