### PR TITLE
Small cleanup

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -13,7 +13,6 @@ Added
 -----
 - Add docker-compose configuration for PostgreSQL
 - Processes can be created on API
- - Add docker-compose configuration for PostgreSQL
 - Enable spawned processes
 
 Changed


### PR DESCRIPTION
To test the skip conditions of the `check_docker()` function, do the following:

1. `RESOLWE_EXECUTOR_COMMAND='dockerbla' ./tests/manage.py test -v 2 resolwe.flow.tests.test_executors.DockerExecutorTestCase`

  This should return something like:
  `test_run_in_docker (resolwe.flow.tests.test_executors.DockerExecutorTestCase) ... skipped u"Docker command 'dockerbla' not found"`

2. `RESOLWE_EXECUTOR_COMMAND='docker bla' ./tests/manage.py test -v 2 resolwe.flow.tests.test_executors.DockerExecutorTestCase`

  This should return something like:
  `test_run_in_docker (resolwe.flow.tests.test_executors.DockerExecutorTestCase) ... skipped u"Docker command 'docker bla info' returned non-zero exit status"`

@mstajdohar: The `check_docker()` code is more complex but more Pythonic - it's a trade-off. It will be nicer once we drop support for Python 2.