### PR TITLE
Make ProcessTestCase._debug_info() robust to non-ascii stdout.txt

### DIFF
--- a/resolwe/flow/utils/test.py
+++ b/resolwe/flow/utils/test.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import copy
 import hashlib
 import gzip
+import io
 import json
 import os
 import shutil
@@ -452,7 +453,7 @@ class ProcessTestCase(TestCase):
         path = os.path.join(settings.FLOW_EXECUTOR['DATA_DIR'], str(data.pk), "stdout.txt")
         if os.path.isfile(path):
             msg += "\nstdout.txt:\n" + 11 * "-" + "\n"
-            with open(path, 'r') as fn:
+            with io.open(path, mode='rt') as fn:
                 msg += fn.read()
 
         if data.process_error:


### PR DESCRIPTION
Fix for error:
`  File "/Users/janez/resolwe/resolwe/flow/utils/test.py", line 442, in _debug_info
    msg += fn.read()
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 2017: ordinal not in range(128)`