### PR TITLE
Ensure we really use our fork of django-autoslug

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,14 +89,14 @@ From PyPI_
 
 .. code::
 
-    pip install resolwe
+    pip install --process-dependency-links resolwe
 
 From source
 -----------
 
 .. code::
 
-   pip install https://github.com/genialis/resolwe/archive/<git-tree-ish>.tar.gz
+   pip install --process-dependency-links https://github.com/genialis/resolwe/archive/<git-tree-ish>.tar.gz
 
 where ``<git-tree-ish>`` can represent any commit SHA, branch name, tag name,
 etc. in `Resolwe's GitHub repository`_. For example, to install the latest
@@ -104,7 +104,7 @@ Resolwe from the ``master`` branch, use:
 
 .. code::
 
-   pip install https://github.com/genialis/resolwe/archive/master.tar.gz
+   pip install --process-dependency-links https://github.com/genialis/resolwe/archive/master.tar.gz
 
 .. _`Resolwe's GitHub repository`: https://github.com/genialis/resolwe/
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -52,7 +52,7 @@ change directory::
 
 Prepare Resolwe for development::
 
-    pip install -e .[docs,package,test]
+    pip install --process-dependency-links -e .[docs,package,test]
 
 .. note::
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         'Django~=1.9.11',
         'djangorestframework>=3.4.0',
         'djangorestframework-filters>=0.9.0',
-        'django-autoslug>=1.9.0',
+        'django-autoslug==1.9.4-dev',
         'django-guardian>=1.4.2',
         'django-mathfilters>=0.3.0',
         # XXX: django-versionfield2 0.5.0 does not work yet:
@@ -66,7 +66,7 @@ setup(
     ],
     dependency_links=[
         # Required due to issue https://github.com/neithere/django-autoslug/pull/18.
-        'git+https://github.com/kostko/django-autoslug.git@fix/empty-slug#egg=django-autoslug-1.9.4',
+        'git+https://github.com/kostko/django-autoslug.git@fix/empty-slug#egg=django-autoslug-1.9.4-dev',
     ],
     extras_require={
         'docs':  [

--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,10 @@ skip_missing_interpreters = True
 # want Tox to install the package from sdist first
 
 [testenv]
+install_command = pip install --process-dependency-links {opts} {packages}
 commands =
 # install testing requirements
-    pip install .[test]
+    pip install --process-dependency-links .[test]
 # run tests
     coverage run --source=resolwe tests/manage.py test --noinput -v 2 {env:TEST_SUITE:resolwe}
 # it is necessary to explicitly list the environment variables that need to be
@@ -18,7 +19,7 @@ passenv = TOXENV RESOLWE_* DOCKER_*
 [testenv:docs]
 commands =
 # install documentation requirements
-    pip install .[docs]
+    pip install --process-dependency-links .[docs]
 # build documentation
 # NOTE: After https://github.com/sphinx-doc/sphinx/pull/2649 is accepted, use:
 # python setup.py build_sphinx --warning-is-error
@@ -29,7 +30,7 @@ commands =
 ignore_errors = True
 commands =
 # install testing requirements
-    pip install .[test]
+    pip install --process-dependency-links .[test]
 # run pylint
     pylint resolwe
 # check PEP 8
@@ -40,7 +41,7 @@ commands =
 [testenv:packaging]
 commands =
 # install testing requirements
-    pip install .[test]
+    pip install --process-dependency-links .[test]
 # confirm that items checked into git are in sdist
     check-manifest
 # verify package metadata and confirm the long_description will render


### PR DESCRIPTION
Add `--process-dependency-links` to Tox commands and documentation.
Specify an exact version of django-autoslug and change it to `1.9.4-dev` so that it matches the actual version used by our fork.