### PR TITLE
Set Docker Compose's project name to 'resolwe' to avoid name clashes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,7 +6,9 @@ recursive-include docs *.py *.rst
 recursive-include docs/example/example/processes *.yml
 recursive-include docs/images *.png
 # include tests and files needed by tests
-include .pylintrc tox.ini
+include tox.ini
+include .pylintrc
+include tests/.env
 recursive-include tests *.py *.yml *.rst
 recursive-include resolwe/flow/tests *.py
 recursive-include resolwe/flow/tests/processes *.yml

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -28,6 +28,7 @@ Changed
 - Split expression engines into expression engines and execution engines
 - Use Jinja2 instead of Django Template syntax
 - Expression engine must be declared in ``requirements``
+- Set Docker Compose's project name to ``resolwe`` to avoid name clashes
 
 Fixed
 -----

--- a/tests/.env
+++ b/tests/.env
@@ -1,0 +1,9 @@
+# Default values of environment variables for Docker Compose
+#
+# NOTE: Values present in the environment at runtime will always override
+# values inside this file. Similarly, values passed via command-line arguments
+# take precedence as well.
+#
+# For more information, see: https://docs.docker.com/compose/env-file/
+# 
+COMPOSE_PROJECT_NAME=resolwe

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -3,7 +3,6 @@
 #
 postgresql:
     image: postgres:9.4
-    container_name: resolwe_postgresql
     environment:
         POSTGRES_USER: resolwe
         POSTGRES_DB: resolwe


### PR DESCRIPTION
By default, project name equals the directory name, where `docker-compose.yml` resides.
Since directory name is `tests`, this is prone to clashes with other projects, so we manually set it to `resolwe`.