### PR TITLE
Preparatory work for adding a custom LiveServerTestCase for process tests that use Resolwe API

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -25,6 +25,7 @@ Added
 - ``data_by_slug`` filter for jinja expression engine
 - Export RESOLWE_API_HOST environment variable in executor
 - Add ``check_installed()`` test utility function
+- Add support for configuring the network mode of Docker executor
 
 Changed
 -------

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -24,6 +24,7 @@ Added
 - Workflow execution engine
 - ``data_by_slug`` filter for jinja expression engine
 - Export RESOLWE_API_HOST environment variable in executor
+- Add ``check_installed()`` test utility function
 
 Changed
 -------

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -32,6 +32,7 @@ Changed
 - Use Jinja2 instead of Django Template syntax
 - Expression engine must be declared in ``requirements``
 - Set Docker Compose's project name to ``resolwe`` to avoid name clashes
+- Expose ``check_docker()`` test utility function
 
 Fixed
 -----

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,6 +77,12 @@ todo_include_todos = False
 
 # Warn about all references where the target cannot be found
 nitpicky = True
+# Except for the following:
+nitpick_ignore = [
+    # This is needed to prevent warnings for container types, e.g.:
+    # :type foo: tuple(bool, str)
+    ('py:obj', ''),
+]
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/resolwe/flow/tests/test_env_vars.py
+++ b/resolwe/flow/tests/test_env_vars.py
@@ -6,7 +6,7 @@ import shutil
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.test import TestCase
+from django.test import override_settings, TestCase
 
 from resolwe.flow.managers import manager
 from resolwe.flow.models import Process, Data
@@ -22,6 +22,7 @@ class EnvVarsTest(TestCase):
             data_dir = os.path.join(settings.FLOW_EXECUTOR['DATA_DIR'], str(data.id))
             shutil.rmtree(data_dir, ignore_errors=True)
 
+    @override_settings(RESOLWE_API_HOST='some.special.host')
     def test_envvars(self):
         process = Process.objects.create(
             name='Test environment variables',
@@ -52,4 +53,4 @@ re-save resolweapihost $RESOLWE_API_HOST
         # update output
         data = Data.objects.get(pk=data.pk)
 
-        self.assertEqual(data.output['resolweapihost'], 'localhost')
+        self.assertEqual(data.output['resolweapihost'], 'some.special.host')

--- a/resolwe/flow/tests/test_executors.py
+++ b/resolwe/flow/tests/test_executors.py
@@ -2,8 +2,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
-import shlex
-import subprocess
 import unittest
 
 import mock
@@ -16,7 +14,7 @@ from django.test import override_settings
 from resolwe.flow.executors.docker import FlowExecutor
 from resolwe.flow.executors import BaseFlowExecutor
 from resolwe.flow.models import Data, Process
-from resolwe.flow.utils.test import ProcessTestCase
+from resolwe.flow.utils.test import check_docker, ProcessTestCase
 
 try:
     import builtins  # py3
@@ -25,29 +23,6 @@ except ImportError:
 
 
 PROCESSES_DIR = os.path.join(os.path.dirname(__file__), 'processes')
-
-
-def check_docker():
-    """Check if Docker is installed and working.
-
-    :return: tuple (indicator of the availability of Docker, reason for
-             unavailability)
-    :rtype: (bool, str)
-
-    """
-    command = getattr(settings, 'FLOW_EXECUTOR', {}).get('COMMAND', 'docker')
-    info_command = '{} info'.format(command)
-    available, reason = True, ""
-    # TODO: use subprocess.DEVNULL after dropping support for Python 2
-    with open(os.devnull, 'wb') as DEVNULL:  # pylint: disable=invalid-name
-        try:
-            subprocess.check_call(shlex.split(info_command), stdout=DEVNULL, stderr=subprocess.STDOUT)
-        except OSError:
-            available, reason = False, "Docker command '{}' not found".format(command)
-        except subprocess.CalledProcessError:
-            available, reason = (False, "Docker command '{}' returned non-zero "
-                                        "exit status".format(info_command))
-    return available, reason
 
 
 class DockerExecutorTestCase(unittest.TestCase):

--- a/resolwe/flow/utils/test.py
+++ b/resolwe/flow/utils/test.py
@@ -18,6 +18,7 @@ import shutil
 import subprocess
 import zipfile
 
+import six
 from six.moves import filterfalse
 
 from django.conf import settings
@@ -31,8 +32,28 @@ from resolwe.flow.models import (Data, dict_dot, iterate_fields, iterate_schema,
                                  DescriptorSchema, Process, Storage)
 from resolwe.flow.managers import manager
 
+if six.PY2:
+    # Monkey-patch shutil package with which function (available in Python 3.3+)
+    import shutilwhich  # pylint: disable=import-error,unused-import
+
 
 SCHEMAS_FIXTURE_CACHE = None
+
+
+def check_installed(command):
+    """Check if the given command is installed.
+
+    :param str command: name of the command
+
+    :return: (indicator of the availability of the command, message saying
+              command is not available)
+    :rtype: tuple(bool, str)
+
+    """
+    if shutil.which(command):
+        return True, ""
+    else:
+        return False, "Command '{}' is not found.".format(command)
 
 
 def check_docker():

--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,10 @@ setup(
             'resolwe-runtime-utils>=1.1.0',
             'testfixtures>=4.10.0',
         ],
+        ':python_version == "2.7"': [
+            # Backport of shutil.which function to Python 2
+            'shutilwhich',
+        ]
     },
 
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
         'PyYAML>=3.11',
         'jsonschema>=2.4.0',
         'six>=1.10.0',
-        'Sphinx>=1.4.6',
+        'Sphinx>=1.5.1',
         'Jinja2>=2.8',
     ],
     dependency_links=[

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -10,8 +10,6 @@ PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 
 SECRET_KEY = 'secret'
 
-RESOLWE_API_HOST = 'localhost'
-
 DEBUG = True
 
 MIDDLEWARE_CLASSES = (

--- a/tox.ini
+++ b/tox.ini
@@ -21,9 +21,7 @@ commands =
 # install documentation requirements
     pip install --process-dependency-links .[docs]
 # build documentation
-# NOTE: After https://github.com/sphinx-doc/sphinx/pull/2649 is accepted, use:
-# python setup.py build_sphinx --warning-is-error
-    sphinx-build -E -W docs/ build/sphinx/html
+    python setup.py build_sphinx --fresh-env --warning-is-error
 
 [testenv:linters]
 # run all linters to see their output even if one of them fails


### PR DESCRIPTION
Contains:
- Upgrade to Sphinx 1.5.1+
- Remove `RESOLWE_API_HOST` setting from test project's settings since it is not really used anywhere
- Expose `check_docker()` test utility function 
- Add `check_installed()` test utility function
- Add support for configuring the network mode of Docker executor

I think it will be easier to review this commit by commit.