### PR TITLE
Prepare release 1.4.1

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -6,9 +6,9 @@ All notable changes to this project are documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 
-==========
-Unreleased
-==========
+==================
+1.4.1 - 2017-01-27
+==================
 
 Fixed
 -----

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -6,6 +6,16 @@ All notable changes to this project are documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 
+==========
+Unreleased
+==========
+
+Fixed
+-----
+- Update instructions on preparing a release to no longer build the wheel
+  distribution which currently fails to install Resolwe's dependency links
+
+
 ==================
 1.4.0 - 2017-01-26
 ==================

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -142,9 +142,21 @@ Create source distribution::
 
     python setup.py sdist
 
-Build wheel::
+.. note::
 
-    python setup.py bdist_wheel
+    Currently, we don't built wheels since they don't have support for
+    dependency links which Resolwe temporarily introduced for a patched version
+    of the `django-autoslug`_ package until an `issue`_ is resolved upstream.
+
+    After this is resolved, the following step will be re-added:
+
+    Build wheel::
+
+        python setup.py bdist_wheel
+
+
+.. _django-autoslug: http://django-autoslug.readthedocs.io/en/latest/ 
+.. _issue: https://github.com/neithere/django-autoslug/pull/18
 
 Upload distribution to PyPI_::
 

--- a/resolwe/__about__.py
+++ b/resolwe/__about__.py
@@ -8,7 +8,7 @@ __url__ = 'https://github.com/genialis/resolwe'
 
 # Semantic versioning is used. For more information see:
 # https://packaging.python.org/en/latest/distributing/#semantic-versioning-preferred
-__version__ = '1.4.0'
+__version__ = '1.4.1'
 
 __author__ = 'Genialis d.o.o.'
 __email__ = 'dev-team@genialis.com'


### PR DESCRIPTION
Fix installation instructions for installing Resolwe from PyPI.

NOTE: Resolwe Bioinformatics was also updated for this in genialis/resolwe-bio#200 PR.