### PR TITLE
Only retain ability to set a custom command for the Docker executor

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -15,11 +15,15 @@ Added
 - Add Resolwe test framework
 - Add ``isort`` linter to check order of imports
 - Support ES test case based on Django's TransactionTestCase
+- Add ability to set a custom command for the Docker executor via the
+  ``FLOW_DOCKER_COMMAND`` setting.
 
 Changed
 -------
 - Support running tests in parallel
 - Split ``flow.models`` module to multiple files
+- Remove ability to set a custom executor command for any executor via
+  the ``FLOW_EXECUTOR['COMMAND']`` setting.
 
 Fixed
 -----

--- a/resolwe/flow/executors/docker.py
+++ b/resolwe/flow/executors/docker.py
@@ -20,7 +20,7 @@ class FlowExecutor(LocalFlowExecutor):
         super(FlowExecutor, self).__init__(*args, **kwargs)
 
         self.mappings_tools = None
-        self.command = getattr(settings, 'FLOW_EXECUTOR', {}).get('COMMAND', 'docker')
+        self.command = getattr(settings, 'FLOW_DOCKER_COMMAND', 'docker')
 
     def start(self):
         """Start process execution."""

--- a/resolwe/flow/executors/local.py
+++ b/resolwe/flow/executors/local.py
@@ -7,8 +7,6 @@ import shlex
 import subprocess
 import time
 
-from django.conf import settings
-
 from resolwe.flow.executors import BaseFlowExecutor
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -27,7 +25,7 @@ class FlowExecutor(BaseFlowExecutor):
         self.kill_delay = 5
         self.proc = None
         self.stdout = None
-        self.command = getattr(settings, 'FLOW_EXECUTOR', {}).get('COMMAND', '/bin/bash')
+        self.command = '/bin/bash'
 
     def start(self):
         """Start process execution."""

--- a/resolwe/test/utils.py
+++ b/resolwe/test/utils.py
@@ -51,7 +51,7 @@ def check_docker():
     :rtype: tuple(bool, str)
 
     """
-    command = getattr(settings, 'FLOW_EXECUTOR', {}).get('COMMAND', 'docker')
+    command = getattr(settings, 'FLOW_DOCKER_COMMAND', 'docker')
     info_command = '{} info'.format(command)
     available, reason = True, ""
     # TODO: Use subprocess.DEVNULL after dropping support for Python 2

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -98,9 +98,9 @@ FLOW_EXECUTOR = {
     'DATA_DIR': os.path.join(PROJECT_ROOT, '.test_data'),
     'UPLOAD_DIR': os.path.join(PROJECT_ROOT, '.test_upload'),
 }
-# Set custom executor command if set via environment variable
-if 'RESOLWE_EXECUTOR_COMMAND' in os.environ:
-    FLOW_EXECUTOR['COMMAND'] = os.environ['RESOLWE_EXECUTOR_COMMAND']
+# Set custom Docker command if set via environment variable
+if 'RESOLWE_DOCKER_COMMAND' in os.environ:
+    FLOW_DOCKER_COMMAND = os.environ['RESOLWE_DOCKER_COMMAND']
 FLOW_API = {
     'PERMISSIONS': 'resolwe.permissions.permissions',
 }


### PR DESCRIPTION
The previous approach to setting a custom executor command didn't scale to more that one executor since the custom command was used by all executors. However, during testing one must be able to run some tests via the local executor and some tests via the Docker executor.

There appears to be no need to set a custom command for the local executor, so we only retained the ability to set a custom command for the Docker executor.

Changed test project's settings to allow setting a custom command for the Docker executor via `RESOLWE_DOCKER_COMMAND` environment variable.