### PR TITLE
Add 'with_custom_executor' and 'with_resolwe_host' test decorators

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -61,6 +61,7 @@ Fixed
 - Generate temporary names for upload files in tests
 - Fix permissions in Elasticsearch tests
 - Do not purge data in tests
+- Remove primary keys before using cached schemas' in process tests
 - Set appropriate SELinux labels when mounting tools in Docker containers
 - Data objects created by the workflow inherite it's permissions
 - If user doesn't have permissions on the latest versions of processes

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -36,6 +36,7 @@ Added
 - Add Null executor
 - If ``choices`` are defined in JSON schema, value of field is
   validated with them
+- Add tests for accessing Resolwe API from a process
 
 Changed
 -------

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -13,6 +13,7 @@ Unreleased
 Added
 -----
 - Add Resolwe test framework
+- Add ``with_custom_executor`` and ``with_resolwe_host`` test decorators
 - Add ``isort`` linter to check order of imports
 - Support basic test case based on Django's ``TransactionTestCase``
 - Support ES test case based on Django's ``TransactionTestCase``

--- a/resolwe/flow/tests/test_access_api.py
+++ b/resolwe/flow/tests/test_access_api.py
@@ -1,0 +1,127 @@
+# pylint: disable=missing-docstring
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import sys
+import unittest
+
+from django.contrib.auth.models import AnonymousUser
+from django.test import LiveServerTestCase
+
+from guardian.shortcuts import assign_perm
+
+from resolwe.flow.models import Collection, Process, Storage
+from resolwe.test import TransactionProcessTestCase, check_installed, with_docker_executor, with_resolwe_host
+
+
+class AccessAPIFromExecutorProcessTestCase(TransactionProcessTestCase, LiveServerTestCase):
+
+    def _create_collection(self):
+        """Create a test collection that will be accessed via a test process.
+
+        Assign :class:`~django.contrib.auth.models.AnonymousUser`
+        ``view_collection`` permission to the created collection.
+
+        :return: created test collection
+        :rtype: Collection
+
+        """
+        collection = Collection.objects.create(
+            name='collection-foo',
+            contributor=self.contributor,
+        )
+        assign_perm("view_collection", AnonymousUser(), collection)
+        return collection
+
+    def create_process(self):
+        """Create a test process that will query the API for collections.
+
+        Get the list of all collections using ``curl`` to query the Live
+        Resolwe host.
+
+        :return: created test process
+        :rtype: Process
+
+        """
+        process = Process.objects.create(
+            name='Test accessing API from process',
+            requirements={'expression-engine': 'jinja'},
+            contributor=self.contributor,
+            type='data:test:api-access',
+            input_schema=[],
+            output_schema=[
+                {
+                    'name': 'collection-list',
+                    'type': 'basic:json:',
+                    'required': False,
+                },
+            ],
+            run={
+                'language': 'bash',
+                # NOTE: Resolwe Runtime Utilities are not available in the
+                # resolwe/test:base Docker image so we need to use plain echo
+                # NOTE: curl must be called with --silent argument to not ouput
+                # its progress since it can interfere with parsing of JSON on
+                # process' standard output
+                'program': r"""
+echo "{\"collection-list\": $(curl --silent --show-error $RESOLWE_HOST_URL/collection)}"
+"""
+            }
+        )
+        return process
+
+    def setUp(self):
+        """Custom initilization of :class:`~TransactionProcessTestCase`."""
+        super(AccessAPIFromExecutorProcessTestCase, self).setUp()
+
+        self.process = self.create_process()
+
+    def check_results(self, data):
+        """Check if information obtained for collection via API is correct."""
+        if 'collection-list' not in data.output:
+            self.fail(
+                "The test process didn't obtain collection list from the live Resolwe host." +
+                self._debug_info(data)
+            )
+        collection_list = Storage.objects.get(data=data).json
+        self.assertEqual(len(collection_list), 1)
+        self.assertEqual(collection_list[0]['slug'], self.collection.slug)
+
+    @unittest.skipUnless(*check_installed('curl'))
+    @with_resolwe_host
+    def test_access_api_from_local_executor_process(self):  # pylint: disable=invalid-name
+        """Test if a process running via local executor can access API."""
+        data = self.run_process(self.process.slug)
+        self.check_results(data)
+
+    @unittest.skipUnless(*check_installed('curl'))
+    def test_access_api_from_local_executor_process_without_decorator(self):  # pylint: disable=invalid-name
+        """Test if a process running via local executor cannot access API."""
+        data = self.run_process(self.process.slug)
+        with self.assertRaises(AssertionError):
+            self.check_results(data)
+
+    @unittest.skipUnless(
+        sys.platform.startswith('linux'),
+        "Accessing live Resolwe host from a Docker container on non-Linux systems is not possible yet."
+    )
+    @with_resolwe_host
+    @with_docker_executor
+    def test_access_api_from_docker_executor_process(self):
+        """Test if a process running via Docker executor can access API."""
+        # pylint: disable=invalid-name
+        # NOTE: pylint gets confused if the above string is inline with the method name
+        data = self.run_process(self.process.slug)
+        self.check_results(data)
+
+    @unittest.skipUnless(
+        sys.platform.startswith('linux'),
+        "Accessing live Resolwe host from a Docker container on non-Linux systems is not possible yet."
+    )
+    @with_docker_executor
+    @with_resolwe_host
+    def test_access_api_from_docker_executor_process_reverse_decorators(self):
+        """Test if a process running via Docker executor can access API."""
+        # pylint: disable=invalid-name
+        # NOTE: pylint gets confused if the above string is inline with the method name
+        data = self.run_process(self.process.slug)
+        self.check_results(data)

--- a/resolwe/test/__init__.py
+++ b/resolwe/test/__init__.py
@@ -16,12 +16,16 @@ from resolwe.test.testcases import TestCase, TransactionTestCase
 from resolwe.test.testcases.api import ResolweAPITestCase
 from resolwe.test.testcases.elastic import ElasticSearchTestCase, TransactionElasticSearchTestCase
 from resolwe.test.testcases.process import ProcessTestCase, TransactionProcessTestCase
-from resolwe.test.utils import check_docker, check_installed, with_docker_executor, with_null_executor
+from resolwe.test.utils import (
+    check_docker, check_installed, with_custom_executor, with_docker_executor, with_null_executor,
+    with_resolwe_host,
+)
 
 __all__ = (
     'TestCase', 'TransactionTestCase',
     'ResolweAPITestCase',
     'ElasticSearchTestCase', 'TransactionElasticSearchTestCase',
     'ProcessTestCase', 'TransactionProcessTestCase',
-    'check_docker', 'check_installed', 'with_docker_executor',
+    'check_docker', 'check_installed', 'with_custom_executor', 'with_docker_executor',
+    'with_null_executor', 'with_resolwe_host',
 )

--- a/resolwe/test/testcases/__init__.py
+++ b/resolwe/test/testcases/__init__.py
@@ -29,6 +29,7 @@ import mock
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
+from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase as DjangoTestCase
 from django.test import TransactionTestCase as DjangoTransactionTestCase
 from django.test import override_settings
@@ -73,6 +74,13 @@ class TransactionTestCase(DjangoTransactionTestCase):
                 continue
 
         return test_data_dir
+
+    def _pre_setup(self, *args, **kwargs):
+        # NOTE: This is a work-around for Django issue #10827
+        # (https://code.djangoproject.com/ticket/10827) that clears the
+        # ContentType cache before permissions are setup.
+        ContentType.objects.clear_cache()
+        super(TransactionTestCase, self)._pre_setup(*args, **kwargs)
 
     def setUp(self):
         """Initialize test data."""

--- a/resolwe/test/testcases/process.py
+++ b/resolwe/test/testcases/process.py
@@ -117,13 +117,25 @@ class TransactionProcessTestCase(TransactionTestCase):
             SCHEMAS_FIXTURE_CACHE[cache_key]['processes'] = list(Process.objects.all())
             SCHEMAS_FIXTURE_CACHE[cache_key]['descriptor_schemas'] = list(DescriptorSchema.objects.all())
 
+    def _create_collection(self):
+        """Create a test collection for admin user.
+
+        :return: created test collection
+        :rtype: Collection
+
+        """
+        return Collection.objects.create(
+            name="Test collection",
+            contributor=self.admin,
+        )
+
     def setUp(self):
         """Initialize test data."""
         super(TransactionProcessTestCase, self).setUp()
 
         self._register_schemas()
 
-        self.collection = Collection.objects.create(contributor=self.admin, name="Test collection")
+        self.collection = self._create_collection()
         self.upload_dir = settings.FLOW_EXECUTOR['UPLOAD_DIR']
 
         self._keep_data = False

--- a/resolwe/test/utils.py
+++ b/resolwe/test/utils.py
@@ -7,6 +7,7 @@ Resolwe Test Helpers and Decorators
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import functools
 import os
 import shlex
 import shutil
@@ -14,6 +15,7 @@ import subprocess
 import unittest
 
 import six
+import wrapt
 
 from django.conf import settings
 from django.test import override_settings
@@ -24,7 +26,10 @@ if six.PY2:
     # Monkey-patch shutil package with which function (available in Python 3.3+)
     import shutilwhich  # pylint: disable=import-error,unused-import
 
-__all__ = ('check_installed', 'check_docker', 'with_docker_executor')
+__all__ = (
+    'check_installed', 'check_docker', 'with_custom_executor', 'with_docker_executor',
+    'with_null_executor', 'with_resolwe_host',
+)
 
 
 def check_installed(command):
@@ -66,16 +71,21 @@ def check_docker():
     return available, reason
 
 
-def with_docker_executor(method):
-    """Decorate unit test to run processes with Docker executor."""
+def with_custom_executor(wrapped=None, **custom_executor_settings):
+    """Decorate unit test to run processes with a custom executor.
+
+    :param dict custom_executor_settings: custom ``FLOW_EXECUTOR``
+        settings with which you wish to override the current settings
+
+    """
+    if wrapped is None:
+        return functools.partial(with_custom_executor, **custom_executor_settings)
+
     # pylint: disable=missing-docstring
-    @unittest.skipUnless(*check_docker())
-    def wrapper(*args, **kwargs):
+    @wrapt.decorator
+    def wrapper(wrapped_method, instance, args, kwargs):
         executor_settings = settings.FLOW_EXECUTOR.copy()
-        executor_settings.update({
-            'NAME': 'resolwe.flow.executors.docker',
-            'CONTAINER_IMAGE': 'resolwe/base',
-        })
+        executor_settings.update(custom_executor_settings)
 
         try:
             with override_settings(FLOW_EXECUTOR=executor_settings):
@@ -83,32 +93,65 @@ def with_docker_executor(method):
                 manager.discover_engines()
 
                 # Run the actual unit test method.
-                method(*args, **kwargs)
+                return wrapped_method(*args, **kwargs)
         finally:
             # Re-run engine discovery as the settings have changed.
             manager.discover_engines()
 
-    return wrapper
+    return wrapper(wrapped)  # pylint: disable=no-value-for-parameter
 
 
-def with_null_executor(method):
-    """Decorate unit test to run processes with Null executor."""
+def with_docker_executor(wrapped=None, image='resolwe/base'):
+    """Decorate unit test to run processes with the Docker executor.
+
+    :param str image: custom Docker image to use when running the Docker
+        executor
+
+    """
+    if wrapped is None:
+        return functools.partial(with_docker_executor, image=image)
+
     # pylint: disable=missing-docstring
-    def wrapper(*args, **kwargs):
-        executor_settings = settings.FLOW_EXECUTOR.copy()
-        executor_settings.update({
-            'NAME': 'resolwe.flow.executors.null',
-        })
+    @wrapt.decorator
+    def wrapper(wrapped_method, instance, args, kwargs):
+        return unittest.skipUnless(*check_docker())(
+            with_custom_executor(
+                NAME='resolwe.flow.executors.docker',
+                CONTAINER_IMAGE=image,
+            )(wrapped_method)
+        )(*args, **kwargs)
 
-        try:
-            with override_settings(FLOW_EXECUTOR=executor_settings):
-                # Re-run engine discovery as the settings have changed.
-                manager.discover_engines()
+    return wrapper(wrapped)  # pylint: disable=no-value-for-parameter
 
-                # Run the actual unit test method.
-                method(*args, **kwargs)
-        finally:
-            # Re-run engine discovery as the settings have changed.
-            manager.discover_engines()
 
-    return wrapper
+@wrapt.decorator
+def with_null_executor(wrapped_method, instance, args, kwargs):
+    """Decorate unit test to run processes with the Null executor."""
+    return with_custom_executor(NAME='resolwe.flow.executors.null')(wrapped_method)(*args, **kwargs)
+
+
+@wrapt.decorator
+def with_resolwe_host(wrapped_method, instance, args, kwargs):
+    """Decorate unit test to give it access to a live Resolwe host.
+
+    Set ``RESOLWE_HOST_URL`` setting to the address where the testing
+    live Resolwe host listens to.
+
+    .. note::
+
+        This decorator must be used with a (sub)class of
+        :class:`~django.test.LiveServerTestCase` which starts a live
+        Django server in the background.
+
+    """
+    if not hasattr(instance, 'server_thread'):
+        raise AttributeError(
+            "with_resolwe_host decorator must be used with a "
+            "(sub)class of LiveServerTestCase that has the "
+            "'server_thread' attribute"
+        )
+    resolwe_host_url = 'http://{host}:{port}'.format(
+        host=instance.server_thread.host, port=instance.server_thread.port)
+    with override_settings(RESOLWE_HOST_URL=resolwe_host_url):
+        # Run the actual unit test method.
+        return with_custom_executor(NETWORK='host')(wrapped_method)(*args, **kwargs)

--- a/resolwe/test/utils.py
+++ b/resolwe/test/utils.py
@@ -74,6 +74,7 @@ def with_docker_executor(method):
         executor_settings = settings.FLOW_EXECUTOR.copy()
         executor_settings.update({
             'NAME': 'resolwe.flow.executors.docker',
+            'CONTAINER_IMAGE': 'resolwe/base',
         })
 
         try:

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
         'six>=1.10.0',
         'Sphinx>=1.5.1',
         'Jinja2>=2.8',
+        'wrapt>=1.10.8',
     ],
     dependency_links=[
         # Required due to issue https://github.com/neithere/django-autoslug/pull/18.

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -96,7 +96,6 @@ STATIC_URL = '/static/'
 
 FLOW_EXECUTOR = {
     'NAME': 'resolwe.flow.executors.local',
-    'CONTAINER_IMAGE': 'resolwe/base',
     'DATA_DIR': os.path.join(PROJECT_ROOT, '.test_data'),
     'UPLOAD_DIR': os.path.join(PROJECT_ROOT, '.test_upload'),
 }


### PR DESCRIPTION
- Add tests for accessing Resolwe API from a process
- Add `TransactionProcessTestCase` based on `TransactionTestCase`

~~**WIP: If tests are run together with some `resolwe.permissions.test_shortcuts.GetObjectsForUser` tests, they fail.**~~

~~For example:~~
```
(resolwe) [tadej@tlinux64 tests (add-resolwe-api-host-tests)]$ ./manage.py test -v 2 resolwe.flow.tests.test_access_api resolwe.permissions.tests.test_shortcuts.GetObjectsForUser.test_has_any_group_permissions
Creating test database for alias 'default' ('resolwe_test')...
Operations to perform:
  Synchronize unmigrated apps: elastic, mathfilters, permissions, resolwe, rest_framework, staticfiles, versionfield
  Apply all migrations: auth, contenttypes, flow, guardian, sessions
Synchronizing apps without migrations:
  Creating tables...
    Running deferred SQL...
Running migrations:
  Applying contenttypes.0001_initial... OK
  Applying contenttypes.0002_remove_content_type_name... OK
  Applying auth.0001_initial... OK
  Applying auth.0002_alter_permission_name_max_length... OK
  Applying auth.0003_alter_user_email_max_length... OK
  Applying auth.0004_alter_user_username_opts... OK
  Applying auth.0005_alter_user_last_login_null... OK
  Applying auth.0006_require_contenttypes_0002... OK
  Applying auth.0007_alter_validators_add_error_messages... OK
  Applying auth.0008_alter_user_username_max_length... OK
  Applying flow.0001_initial... OK
  Applying flow.0002_project_to_collection... OK
  Applying flow.0003_support_sample... OK
  Applying flow.0004_autoslug_field... OK
  Applying flow.0005_process_data_name... OK
  Applying flow.0006_data_named_by_user... OK
  Applying flow.0007_add_owner... OK
  Applying flow.0008_fix_jsonfields... OK
  Applying flow.0009_data_parents... OK
  Applying flow.0010_fix_jsonfields... OK
  Applying flow.0011_calculate_checksum... OK
  Applying flow.0012_require_checksum... OK
  Applying flow.0013_add_requirements... OK
  Applying flow.0014_add_entity... OK
  Applying flow.0015_make_data_indexes... OK
  Applying flow.0016_update_versionfield... OK
  Applying flow.0017_update_checksum... OK
  Applying flow.0018_remove_triggers... OK
  Applying flow.0019_data_descriptor_dirty... OK
  Applying flow.0020_collection_descriptor_dirty... OK
  Applying flow.0021_entity_descriptor_completed... OK
  Applying guardian.0001_initial... OK
  Applying sessions.0001_initial... OK
test_has_any_group_permissions (resolwe.permissions.tests.test_shortcuts.GetObjectsForUser) ... ok
test_access_api_from_docker_executor_process (resolwe.flow.tests.test_access_api.AccessAPIFromExecutorProcessTestCase)
Test if a process running via Docker executor can access API. ... ok
ERROR
test_access_api_from_docker_executor_process_reverse_decorators (resolwe.flow.tests.test_access_api.AccessAPIFromExecutorProcessTestCase)
Test if a process running via Docker executor can access API. ... ERROR
ERROR
test_access_api_from_local_executor_process (resolwe.flow.tests.test_access_api.AccessAPIFromExecutorProcessTestCase)
Test if a process running via local executor can access API. ... ERROR
ERROR

======================================================================
ERROR: test_access_api_from_docker_executor_process (resolwe.flow.tests.test_access_api.AccessAPIFromExecutorProcessTestCase)
Test if a process running via Docker executor can access API.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/db/backends/base/base.py", line 211, in _commit
    return self.connection.commit()
psycopg2.IntegrityError: insert or update on table "auth_permission" violates foreign key constraint "auth_permiss_content_type_id_2f476e4b_fk_django_content_type_id"
DETAIL:  Key (content_type_id)=(1) is not present in table "django_content_type".


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/test/testcases.py", line 216, in __call__
    self._post_teardown()
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/test/testcases.py", line 908, in _post_teardown
    self._fixture_teardown()
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/test/testcases.py", line 943, in _fixture_teardown
    inhibit_post_migrate=inhibit_post_migrate)
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/core/management/__init__.py", line 130, in call_command
    return command.execute(*args, **defaults)
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/core/management/base.py", line 345, in execute
    output = self.handle(*args, **options)
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/core/management/commands/flush.py", line 88, in handle
    emit_post_migrate_signal(verbosity, interactive, database)
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/core/management/sql.py", line 53, in emit_post_migrate_signal
    **kwargs
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/dispatch/dispatcher.py", line 191, in send
    response = receiver(signal=self, sender=sender, **named)
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/contrib/auth/management/__init__.py", line 83, in create_permissions
    Permission.objects.using(using).bulk_create(perms)
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/db/models/query.py", line 458, in bulk_create
    obj_without_pk._state.db = self.db
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/db/transaction.py", line 223, in __exit__
    connection.commit()
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/db/backends/base/base.py", line 242, in commit
    self._commit()
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/db/backends/base/base.py", line 211, in _commit
    return self.connection.commit()
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/db/utils.py", line 94, in __exit__
    six.reraise(dj_exc_type, dj_exc_value, traceback)
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/utils/six.py", line 685, in reraise
    raise value.with_traceback(tb)
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/db/backends/base/base.py", line 211, in _commit
    return self.connection.commit()
django.db.utils.IntegrityError: insert or update on table "auth_permission" violates foreign key constraint "auth_permiss_content_type_id_2f476e4b_fk_django_content_type_id"
DETAIL:  Key (content_type_id)=(1) is not present in table "django_content_type".


======================================================================
ERROR: test_access_api_from_docker_executor_process_reverse_decorators (resolwe.flow.tests.test_access_api.AccessAPIFromExecutorProcessTestCase)
Test if a process running via Docker executor can access API.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/tadej/Genialis/resolwe/resolwe/flow/tests/test_access_api.py", line 73, in setUp
    self.collection = self.create_collection()
  File "/home/tadej/Genialis/resolwe/resolwe/flow/tests/test_access_api.py", line 33, in create_collection
    assign_perm("view_collection", AnonymousUser(), collection)
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/guardian/shortcuts.py", line 69, in assign_perm
    user, group = get_identity(user_or_group)
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/guardian/utils.py", line 74, in get_identity
    identity = get_anonymous_user()
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/guardian/utils.py", line 39, in get_anonymous_user
    return User.objects.get(**lookup)
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/db/models/query.py", line 385, in get
    self.model._meta.object_name
django.contrib.auth.models.DoesNotExist: User matching query does not exist.

======================================================================
ERROR: test_access_api_from_docker_executor_process_reverse_decorators (resolwe.flow.tests.test_access_api.AccessAPIFromExecutorProcessTestCase)
Test if a process running via Docker executor can access API.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/db/backends/base/base.py", line 211, in _commit
    return self.connection.commit()
psycopg2.IntegrityError: insert or update on table "auth_permission" violates foreign key constraint "auth_permiss_content_type_id_2f476e4b_fk_django_content_type_id"
DETAIL:  Key (content_type_id)=(15) is not present in table "django_content_type".


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/test/testcases.py", line 216, in __call__
    self._post_teardown()
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/test/testcases.py", line 908, in _post_teardown
    self._fixture_teardown()
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/test/testcases.py", line 943, in _fixture_teardown
    inhibit_post_migrate=inhibit_post_migrate)
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/core/management/__init__.py", line 130, in call_command
    return command.execute(*args, **defaults)
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/core/management/base.py", line 345, in execute
    output = self.handle(*args, **options)
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/core/management/commands/flush.py", line 88, in handle
    emit_post_migrate_signal(verbosity, interactive, database)
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/core/management/sql.py", line 53, in emit_post_migrate_signal
    **kwargs
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/dispatch/dispatcher.py", line 191, in send
    response = receiver(signal=self, sender=sender, **named)
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/contrib/auth/management/__init__.py", line 83, in create_permissions
    Permission.objects.using(using).bulk_create(perms)
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/db/models/query.py", line 458, in bulk_create
    obj_without_pk._state.db = self.db
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/db/transaction.py", line 223, in __exit__
    connection.commit()
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/db/backends/base/base.py", line 242, in commit
    self._commit()
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/db/backends/base/base.py", line 211, in _commit
    return self.connection.commit()
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/db/utils.py", line 94, in __exit__
    six.reraise(dj_exc_type, dj_exc_value, traceback)
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/utils/six.py", line 685, in reraise
    raise value.with_traceback(tb)
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/db/backends/base/base.py", line 211, in _commit
    return self.connection.commit()
django.db.utils.IntegrityError: insert or update on table "auth_permission" violates foreign key constraint "auth_permiss_content_type_id_2f476e4b_fk_django_content_type_id"
DETAIL:  Key (content_type_id)=(15) is not present in table "django_content_type".


======================================================================
ERROR: test_access_api_from_local_executor_process (resolwe.flow.tests.test_access_api.AccessAPIFromExecutorProcessTestCase)
Test if a process running via local executor can access API.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/tadej/Genialis/resolwe/resolwe/flow/tests/test_access_api.py", line 73, in setUp
    self.collection = self.create_collection()
  File "/home/tadej/Genialis/resolwe/resolwe/flow/tests/test_access_api.py", line 33, in create_collection
    assign_perm("view_collection", AnonymousUser(), collection)
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/guardian/shortcuts.py", line 69, in assign_perm
    user, group = get_identity(user_or_group)
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/guardian/utils.py", line 74, in get_identity
    identity = get_anonymous_user()
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/guardian/utils.py", line 39, in get_anonymous_user
    return User.objects.get(**lookup)
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/db/models/query.py", line 385, in get
    self.model._meta.object_name
django.contrib.auth.models.DoesNotExist: User matching query does not exist.

======================================================================
ERROR: test_access_api_from_local_executor_process (resolwe.flow.tests.test_access_api.AccessAPIFromExecutorProcessTestCase)
Test if a process running via local executor can access API.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/db/backends/base/base.py", line 211, in _commit
    return self.connection.commit()
psycopg2.IntegrityError: insert or update on table "auth_permission" violates foreign key constraint "auth_permiss_content_type_id_2f476e4b_fk_django_content_type_id"
DETAIL:  Key (content_type_id)=(15) is not present in table "django_content_type".


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/test/testcases.py", line 216, in __call__
    self._post_teardown()
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/test/testcases.py", line 908, in _post_teardown
    self._fixture_teardown()
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/test/testcases.py", line 943, in _fixture_teardown
    inhibit_post_migrate=inhibit_post_migrate)
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/core/management/__init__.py", line 130, in call_command
    return command.execute(*args, **defaults)
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/core/management/base.py", line 345, in execute
    output = self.handle(*args, **options)
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/core/management/commands/flush.py", line 88, in handle
    emit_post_migrate_signal(verbosity, interactive, database)
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/core/management/sql.py", line 53, in emit_post_migrate_signal
    **kwargs
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/dispatch/dispatcher.py", line 191, in send
    response = receiver(signal=self, sender=sender, **named)
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/contrib/auth/management/__init__.py", line 83, in create_permissions
    Permission.objects.using(using).bulk_create(perms)
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/db/models/query.py", line 458, in bulk_create
    obj_without_pk._state.db = self.db
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/db/transaction.py", line 223, in __exit__
    connection.commit()
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/db/backends/base/base.py", line 242, in commit
    self._commit()
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/db/backends/base/base.py", line 211, in _commit
    return self.connection.commit()
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/db/utils.py", line 94, in __exit__
    six.reraise(dj_exc_type, dj_exc_value, traceback)
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/utils/six.py", line 685, in reraise
    raise value.with_traceback(tb)
  File "/home/tadej/.virtualenvs/resolwe/lib/python3.5/site-packages/django/db/backends/base/base.py", line 211, in _commit
    return self.connection.commit()
django.db.utils.IntegrityError: insert or update on table "auth_permission" violates foreign key constraint "auth_permiss_content_type_id_2f476e4b_fk_django_content_type_id"
DETAIL:  Key (content_type_id)=(15) is not present in table "django_content_type".


----------------------------------------------------------------------
Ran 4 tests in 4.155s

FAILED (errors=5)
Destroying test database for alias 'default' ('resolwe_test')...
```

~~Any ideas what is causing the failure?~~