### PR TITLE
Set appropriate SELinux labels when mounting tools in Docker containers

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -39,6 +39,7 @@ Fixed
 - Generate temporary names for upload files in tests
 - Fix permissions in Elasticsearch tests
 - Do not purge data in tests
+- Set appropriate SELinux labels when mounting tools in Docker containers
 
 
 ==================

--- a/resolwe/flow/executors/docker.py
+++ b/resolwe/flow/executors/docker.py
@@ -48,7 +48,9 @@ class FlowExecutor(LocalFlowExecutor):
 
         # create mappings for tools
         # NOTE: To prevent processes tampering with tools, all tools are mounted read-only
-        self.mappings_tools = [{'src': tool, 'dest': '/usr/local/bin/resolwe/{}'.format(i), 'mode': 'ro'}
+        # NOTE: Since the tools are shared among all containers they must use the shared SELinux
+        # label (z option)
+        self.mappings_tools = [{'src': tool, 'dest': '/usr/local/bin/resolwe/{}'.format(i), 'mode': 'ro,z'}
                                for i, tool in enumerate(self.get_tools())]
         mappings += self.mappings_tools
         # create Docker --volume parameters from mappings


### PR DESCRIPTION
This is needed on hosts where SELinux is enabled.

@dblenkus, @mstajdohar, can you please run (one) [process test case in Resolwe Bioinformatics](https://github.com/genialis/resolwe-bio/tree/master/resolwe_bio/tests/processes) with this PR since I'm not sure how this new flag behaves on systems without SELinux.