### PR TITLE
Improve MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -19,8 +19,9 @@ recursive-include resolwe/flow/tests/files/processes *.yaml
 include resolwe/flow/tests/fixtures/*.yaml
 recursive-include resolwe/permissions/tests *.py
 recursive-include resolwe/permissions/fixtures *.yaml readme.txt
-recursive-include resolwe/toolkit *.py *.yml
-recursive-include resolwe/toolkit/docker_images Dockerfile README.md
+recursive-include resolwe/toolkit/tests *.py
 recursive-include resolwe/toolkit/tests/files *
+# include Dockerfiles and files needed to build Docker images
+recursive-include resolwe/toolkit/docker_images Dockerfile README.md
 include resolwe/toolkit/docker_images/base/curlprogress.py
 include resolwe/toolkit/docker_images/base/re-import.sh


### PR DESCRIPTION
Only include Python files under `resolwe/toolkit/tests`, not the whole `resolwe/toolkit` directory.
Move includes for `Dockerfiles` and files needed to build Docker images together.