### PR TITLE
Support field projection via REST API

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,93 @@
+===
+API
+===
+
+The Resolwe framework provides a RESTful API through which most of its
+functionality is exposed.
+
+TODO
+
+Limiting fields in responses
+============================
+
+As responses from the Resolwe API can contain a lot of data, especially with
+nested JSON outputs and schemas, the API provides a way of limiting what is
+returned with each response.
+
+This is achieved through the use of a special ``fields`` GET parameter, which
+can specify one or multiple field projections. Each projection defines what
+should be returned. As a working example, let's assume we have the following
+API response when no field projections are applied:
+
+.. code:: json
+
+    [
+        {
+            "foo": {
+                "name": "Foo",
+                "bar": {
+                    "level3": 42,
+                    "another": "hello"
+                }
+            },
+            "name": "Boo"
+        },
+        {
+            "foo": {
+                "name": "Different",
+            },
+            "name": "Another"
+        }
+    ]
+
+A field projection may reference any of the top-level fields. For example, by
+using the ``fields=name`` projection, we get the following result:
+
+.. code:: json
+
+    [
+        {
+            "name": "Boo"
+        },
+        {
+            "name": "Another"
+        }
+    ]
+
+Basically all fields not matching the projection are gone. We can go further
+and also project deeply nested fields, e.g., ``fields=foo__name``:
+
+.. code:: json
+
+    [
+        {
+            "foo": {
+                "name": "Foo"
+            }
+        },
+        {
+            "foo": {
+                "name": "Different"
+            }
+        }
+    ]
+
+And at last, we can combine multiple projections by separating them with commas,
+e.g., ``fields=name,foo__name``, giving us:
+
+.. code:: json
+
+    [
+        {
+            "foo": {
+                "name": "Foo"
+            },
+            "name": "Boo"
+        },
+        {
+            "foo": {
+                "name": "Different"
+            },
+            "name": "Another"
+        }
+    ]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,7 @@ Contents
    overview
    intro
    proc
+   api
    ref
    CHANGELOG
    contributing

--- a/resolwe/rest/__init__.py
+++ b/resolwe/rest/__init__.py
@@ -1,0 +1,1 @@
+"""Resolwe REST API helpers."""

--- a/resolwe/rest/fields.py
+++ b/resolwe/rest/fields.py
@@ -1,0 +1,15 @@
+"""Support for selective field serialization."""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from rest_framework.fields import JSONField
+
+from .projection import apply_subfield_projection
+
+
+class ProjectableJSONField(JSONField):
+    """JSON field which supports projection."""
+
+    def to_representation(self, value):
+        """Project outgoing native value."""
+        value = apply_subfield_projection(self, value, deep=True)
+        return super(ProjectableJSONField, self).to_representation(value)

--- a/resolwe/rest/projection.py
+++ b/resolwe/rest/projection.py
@@ -1,0 +1,93 @@
+"""Implementation of field projection."""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from collections import Mapping, Sequence
+
+FIELD_SEPARATOR = ','
+FIELD_DEREFERENCE = '__'
+
+
+def apply_subfield_projection(field, value, deep=False):
+    """Apply projection from request context.
+
+    The passed dictionary may be mutated.
+
+    :param field: An instance of `Field` or `Serializer`
+    :type field: `Field` or `Serializer`
+    :param value: Dictionary to apply the projection to
+    :type value: dict
+    :param deep: Also process all deep projections
+    :type deep: bool
+    """
+    # Discover the root manually. We cannot use either `self.root` or `self.context`
+    # due to a bug with incorrect caching (see DRF issue #5087).
+    prefix = []
+    root = field
+    while root.parent is not None:
+        # Skip anonymous serializers (e.g., intermediate ListSerializers).
+        if root.field_name:
+            prefix.append(root.field_name)
+        root = root.parent
+    prefix = prefix[::-1]
+
+    context = getattr(root, '_context', {})
+
+    # If there is no request, we cannot perform filtering.
+    request = context.get('request')
+    if request is None:
+        return value
+
+    filtered = set(request.query_params.get('fields', '').split(FIELD_SEPARATOR))
+    filtered.discard('')
+    if not filtered:
+        # If there are no fields specified in the filter, return all fields.
+        return value
+
+    # Extract projection for current and deeper levels.
+    current_level = len(prefix)
+    current_projection = []
+    for item in filtered:
+        item = item.split(FIELD_DEREFERENCE)
+        if len(item) <= current_level:
+            continue
+
+        if item[:current_level] == prefix:
+            if deep:
+                current_projection.append(item[current_level:])
+            else:
+                current_projection.append([item[current_level]])
+
+    # Apply projection.
+    return apply_projection(current_projection, value)
+
+
+def apply_projection(projection, value):
+    """Apply projection."""
+    if isinstance(value, Sequence):
+        # Apply projection to each item in the list.
+        return [
+            apply_projection(projection, item)
+            for item in value
+        ]
+    elif not isinstance(value, Mapping):
+        # Non-dictionary values are simply ignored.
+        return value
+
+    # Extract projection for current level.
+    try:
+        current_projection = [p[0] for p in projection]
+    except IndexError:
+        return value
+
+    # Apply projection.
+    for name in list(value.keys()):
+        if name not in current_projection:
+            value.pop(name)
+        elif isinstance(value[name], dict):
+            # Apply projection recursively.
+            value[name] = apply_projection(
+                [p[1:] for p in projection if p[0] == name],
+                value[name]
+            )
+
+    return value

--- a/resolwe/rest/serializers.py
+++ b/resolwe/rest/serializers.py
@@ -1,0 +1,16 @@
+"""Support for selective field serialization."""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import copy
+
+from .projection import apply_subfield_projection
+
+
+class SelectiveFieldMixin(object):
+    """Mixin that enables field selection based on request arguments."""
+
+    @property
+    def fields(self):
+        """Filter fields based on request query parameters."""
+        fields = super(SelectiveFieldMixin, self).fields
+        return apply_subfield_projection(self, copy.copy(fields))

--- a/resolwe/rest/tests.py
+++ b/resolwe/rest/tests.py
@@ -1,0 +1,77 @@
+# pylint: disable=missing-docstring
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import itertools
+
+import six
+
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from resolwe.flow.models import Data, Entity, Process
+from resolwe.flow.views import EntityViewSet
+from resolwe.test import TestCase
+
+factory = APIRequestFactory()  # pylint: disable=invalid-name
+
+
+class ProjectionTest(TestCase):
+    def setUp(self):
+        super(ProjectionTest, self).setUp()
+
+        self.entity = Entity.objects.create(name="Test entity", contributor=self.contributor)
+        process = Process.objects.create(
+            name="Test process",
+            contributor=self.contributor,
+            output_schema=[
+                {'name': 'foo', 'label': 'Foo', 'group': [
+                    {'name': 'bar', 'label': 'Bar', 'type': 'basic:integer:'},
+                    {'name': 'hello', 'label': 'Hello', 'type': 'basic:string:'},
+                ]},
+                {'name': 'another', 'label': 'Another', 'type': 'basic:integer:'},
+            ]
+        )
+        data_output = {
+            'foo': {
+                'bar': 42,
+                'hello': 'world',
+            },
+            'another': 3,
+        }
+        self.data = Data.objects.create(name="Test data", contributor=self.contributor, process=process,
+                                        output=data_output)
+        self.data_2 = Data.objects.create(name="Test data 2", contributor=self.contributor, process=process,
+                                          output=data_output)
+
+        self.entity.data.add(self.data)
+        self.entity.data.add(self.data_2)
+
+        self.entity_viewset = EntityViewSet.as_view(actions={'get': 'list'})
+
+    def get_projection(self, fields):
+        request = factory.get('/', {'fields': ','.join(fields), 'hydrate_data': '1'}, format='json')
+        force_authenticate(request, self.admin)
+        return self.entity_viewset(request).data
+
+    def test_projection(self):
+        # Test top-level projection.
+        all_fields = self.get_projection([])[0].keys()
+        for field_count in range(1, 3):
+            for fields in itertools.combinations(all_fields, field_count):
+                data = self.get_projection(fields)[0]
+                six.assertCountEqual(self, data.keys(), set(fields + ('permissions',)))
+
+        # Test nested projection.
+        data = self.get_projection(['data__name'])[0]
+        six.assertCountEqual(self, data.keys(), ['data', 'permissions'])
+        self.assertEqual(len(data['data']), 2)
+        for item in data['data']:
+            six.assertCountEqual(self, item.keys(), ['name'])
+
+        # Test nested projection into JSON.
+        data = self.get_projection(['data__name', 'data__output__foo__bar'])[0]
+        self.assertEqual(len(data['data']), 2)
+        for item in data['data']:
+            six.assertCountEqual(self, item.keys(), ['name', 'output'])
+            six.assertCountEqual(self, item['output'].keys(), ['foo'])
+            six.assertCountEqual(self, item['output']['foo'].keys(), ['bar'])
+            self.assertEqual(item['output']['foo']['bar'], 42)

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ commands =
 # check PEP 8
     pycodestyle resolwe
 # check PEP 257
-    pydocstyle resolwe
+    pydocstyle resolwe --match='(?!test[_s]).*\.py'
 # check order of imports
     isort --recursive --check-only --diff resolwe
 


### PR DESCRIPTION
Adds support for projections like this:
* `data` (top-level projection)
* `name` (top-level projection)
* `descriptor_schema__name` (nested projection)
* `data__name` (nested projection)
* `descriptor_schema__schema__name` (nested projection + projection into JSON field)
* `data__input__reads` (nested projection + projection into JSON field)
* `data__output__bam__file` (nested projection + deep projection into JSON field)

TODO:
* [x] Tests
* [x] Documentation