### PR TITLE
Revert "Work-around for an issue with the latest setuptools (36.0.0)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,6 @@ env:
     - RESOLWE_POSTGRESQL_USER=postgres
     - RESOLWE_POSTGRESQL_PORT=5432
     - RESOLWE_ES_PORT=9200
-    # XXX: Work-around for the "No module named 'six'" issue with the latest
-    # version of setuptools (36.0.0):
-    # https://github.com/pypa/setuptools/issues/1042
-    - VIRTUALENV_NO_DOWNLOAD=1
 
 # NOTE: Explicit Python versions make Travis job description more informative
 matrix:


### PR DESCRIPTION
This reverts commit b12516e5c9c217f3e1a452ace53df635ed1e4508.
The issue has been fixed in [setuptools 36.0.1](https://setuptools.readthedocs.io/en/latest/history.html#v36-0-1).