### PR TITLE
Remove redundant _pre_setup() in TestManager

### DIFF
--- a/resolwe/flow/tests/test_manager.py
+++ b/resolwe/flow/tests/test_manager.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 
-from django.contrib.contenttypes.models import ContentType
 from django.db import transaction
 
 from guardian.shortcuts import assign_perm
@@ -18,13 +17,6 @@ PROCESSES_DIR = os.path.join(os.path.dirname(__file__), 'processes')
 #       of this it should be tested in TransactionTestCase, as it won't
 #       be triggered if whole test is wrapped in a transaction.
 class TestManager(TransactionProcessTestCase):
-
-    def _pre_setup(self, *args, **kwargs):
-        # NOTE: This is a work-around for Django issue #10827
-        # (https://code.djangoproject.com/ticket/10827) that clears the
-        # ContentType cache before permissions are setup.
-        ContentType.objects.clear_cache()
-        super(TestManager, self)._pre_setup(*args, **kwargs)
 
     def setUp(self):
         super(TestManager, self).setUp()

--- a/resolwe/test/testcases/__init__.py
+++ b/resolwe/test/testcases/__init__.py
@@ -75,6 +75,13 @@ class TransactionTestCase(DjangoTransactionTestCase):
 
         return test_data_dir
 
+    def _pre_setup(self, *args, **kwargs):
+        # NOTE: This is a work-around for Django issue #10827
+        # (https://code.djangoproject.com/ticket/10827) that clears the
+        # ContentType cache before permissions are setup.
+        ContentType.objects.clear_cache()
+        super(TransactionTestCase, self)._pre_setup(*args, **kwargs)
+
     def setUp(self):
         """Initialize test data."""
         super(TransactionTestCase, self).setUp()


### PR DESCRIPTION
This also reverts https://github.com/genialis/resolwe/commit/9c6e73c309c08084cbbcf2df724babdf644deeea, which deleted the redundant code in the parent class (`TransactionTestCase`) which caused [various](https://travis-ci.org/genialis/resolwe/jobs/244912493) [random](https://travis-ci.org/genialis/resolwe/jobs/244912495) [Travis](https://travis-ci.org/genialis/resolwe/jobs/244912496) [build](https://travis-ci.org/genialis/resolwe/jobs/244937632) [failures](https://travis-ci.org/genialis/resolwe/jobs/244937633).