### PR TITLE
Update toolkit's base image to Fedora 26

### DIFF
--- a/resolwe/toolkit/docker_images/base/Dockerfile
+++ b/resolwe/toolkit/docker_images/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/fedora:25
+FROM docker.io/fedora:26
 
 LABEL MAINTAINER Resolwe authors https://github.com/genialis/resolwe
 


### PR DESCRIPTION
This version of Fedora coerces the C locale to C.UTF-8 which means Python 3 will have C.UTF-8 set as the default locale.