### PR TITLE
Temporarily pin urllib3 to version 1.12.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,9 @@ setup(
         'Sphinx>=1.5.1',
         'Jinja2>=2.8',
         'wrapt>=1.10.8',
+        # XXX: Temporarily pin urllib3 since the latest version of the requests
+        # package (2.18.1) explicitly requires urllib3<1.22,>=1.21.1
+        'urllib3==1.21.1',
     ],
     extras_require={
         'docs':  [

--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,18 @@ skip_missing_interpreters = True
 # NOTE: Don't use 'deps = .[<extra-requirements>]' tox option since we
 # want Tox to install the package from sdist first
 
+# NOTE: Running 'pip check' after installation is necessary since pip currently
+# lacks dependency resolution which means it can silently create broken
+# installations.
+# For more details, see: https://github.com/pypa/pip/issues/988
+
 [testenv]
 install_command = pip install {opts} {packages}
 commands =
 # install testing requirements
     pip install .[test]
+# verify installed packages have compatible dependencies
+    pip check
 # run tests
     coverage run tests/manage.py test {env:TEST_SUITE:resolwe} --noinput --verbosity=2 --parallel
     coverage combine
@@ -21,6 +28,8 @@ passenv = TOXENV RESOLWE_* DOCKER_* TRAVIS
 commands =
 # install documentation requirements
     pip install .[docs]
+# verify installed packages have compatible dependencies
+    pip check
 # build documentation
     python setup.py build_sphinx --fresh-env --warning-is-error
 
@@ -30,6 +39,8 @@ ignore_errors = True
 commands =
 # install testing requirements
     pip install .[test]
+# verify installed packages have compatible dependencies
+    pip check
 # run pylint
     pylint resolwe
 # check PEP 8
@@ -43,6 +54,8 @@ commands =
 commands =
 # install testing requirements
     pip install .[test]
+# verify installed packages have compatible dependencies
+    pip check
 # confirm that items checked into git are in sdist
     check-manifest
 # verify package metadata and confirm the long_description will render


### PR DESCRIPTION
This should fix the current testing issues since the latest urllib3 version (1.22) is incompatible with the latest version of requests (2.18.1):

```
$ pip check
requests 2.18.1 has requirement urllib3<1.22,>=1.21.1, but you have urllib3 1.22.
```

Run `pip check` to detect incompatible dependencies.