### PR TITLE
Specify tag of the required base Docker image

### DIFF
--- a/resolwe/test/utils.py
+++ b/resolwe/test/utils.py
@@ -101,7 +101,7 @@ def with_custom_executor(wrapped=None, **custom_executor_settings):
     return wrapper(wrapped)  # pylint: disable=no-value-for-parameter
 
 
-def with_docker_executor(wrapped=None, image='resolwe/base'):
+def with_docker_executor(wrapped=None, image='resolwe/base:fedora-26'):
     """Decorate unit test to run processes with the Docker executor.
 
     :param str image: custom Docker image to use when running the Docker

--- a/resolwe/toolkit/docker_images/archiver/README.md
+++ b/resolwe/toolkit/docker_images/archiver/README.md
@@ -1,4 +1,4 @@
 # Docker image for archiver process
 
-It is based on [`docker.io/resolwe/base`](
+It is based on [`docker.io/resolwe/base:fedora-26`](
 https://hub.docker.com/r/resolwe/base/).

--- a/resolwe/toolkit/docker_images/upload-tab-file/README.md
+++ b/resolwe/toolkit/docker_images/upload-tab-file/README.md
@@ -1,4 +1,4 @@
 # Docker image for upload-tab-file process
 
-It is based on [`docker.io/resolwe/base`](
+It is based on [`docker.io/resolwe/base:fedora-26`](
 https://hub.docker.com/r/resolwe/base/).


### PR DESCRIPTION
Set the fedora-26 tag of the resolwe/base Docker image where it was previously used without a tag.