### PR TITLE
Use /etc/profile.d instead of .bash_profile

### DIFF
--- a/resolwe/toolkit/docker_images/base/Dockerfile.fedora-26
+++ b/resolwe/toolkit/docker_images/base/Dockerfile.fedora-26
@@ -10,10 +10,10 @@ COPY curlprogress.py /usr/local/bin/
 
 RUN pip3 install resolwe-runtime-utils && \
     # XXX: Remove this hack after obsoleting re-checkrc
-    echo 're-checkrc() { _re-checkrc $? "$@"; }' >> ~/.bash_profile && \
+    echo 're-checkrc() { _re-checkrc $? "$@"; }' >> /etc/profile.d/resolwe-base.sh && \
     # XXX: Remove this hack after updating processes to no longer implicitly assume $NAME is set
     # when calling re-import.sh
-    cat /re-import.sh >> ~/.bash_profile && \
+    cat /re-import.sh >> /etc/profile.d/resolwe-base.sh && \
     rm /re-import.sh && \
     # XXX: Remove this after Resolwe learns how to mount re-* tools into every container
     chmod +x /usr/local/bin/curlprogress.py

--- a/resolwe/toolkit/docker_images/base/Dockerfile.ubuntu-14.04
+++ b/resolwe/toolkit/docker_images/base/Dockerfile.ubuntu-14.04
@@ -13,10 +13,10 @@ RUN apt-get update && \
     # Install Resolwe Runtime Utils
     pip3 install resolwe-runtime-utils && \
     # XXX: Remove this hack after obsoleting re-checkrc
-    echo 're-checkrc() { _re-checkrc $? "$@"; }' >> ~/.bash_profile && \
+    echo 're-checkrc() { _re-checkrc $? "$@"; }' >> /etc/profile.d/resolwe-base.sh && \
     # XXX: Remove this hack after updating processes to no longer implicitly assume $NAME is set
     # when calling re-import.sh
-    cat /re-import.sh >> ~/.bash_profile && \
+    cat /re-import.sh >> /etc/profile.d/resolwe-base.sh && \
     rm /re-import.sh && \
     # XXX: Remove this after Resolwe learns how to mount re-* tools into every container
     chmod +x /usr/local/bin/curlprogress.py && \

--- a/resolwe/toolkit/docker_images/base/Dockerfile.ubuntu-16.04
+++ b/resolwe/toolkit/docker_images/base/Dockerfile.ubuntu-16.04
@@ -13,10 +13,10 @@ RUN apt-get update && \
     # Install Resolwe Runtime Utils
     pip3 install resolwe-runtime-utils && \
     # XXX: Remove this hack after obsoleting re-checkrc
-    echo 're-checkrc() { _re-checkrc $? "$@"; }' >> ~/.bash_profile && \
+    echo 're-checkrc() { _re-checkrc $? "$@"; }' >> /etc/profile.d/resolwe-base.sh && \
     # XXX: Remove this hack after updating processes to no longer implicitly assume $NAME is set
     # when calling re-import.sh
-    cat /re-import.sh >> ~/.bash_profile && \
+    cat /re-import.sh >> /etc/profile.d/resolwe-base.sh && \
     rm /re-import.sh && \
     # XXX: Remove this after Resolwe learns how to mount re-* tools into every container
     chmod +x /usr/local/bin/curlprogress.py && \


### PR DESCRIPTION
Using the root user's `.bash_profile` is very ugly and should be avoided. It may also become unsupported (e.g. will not be evaluated), based on how we implement running as the correct user.

In genialis/resolwe-bio#335 the relevant section will also change to use `/etc/profile.d/resolwebio-legacy.sh` instead. Other Docker images should follow the same naming convention, each creating its own file in `/etc/profile.d`.