### PR TITLE
Bump versions of modified toolkit processes

### DIFF
--- a/resolwe/flow/tests/processes/tests.yml
+++ b/resolwe/flow/tests/processes/tests.yml
@@ -286,7 +286,7 @@
   requirements:
     executor:
       docker:
-        image: "resolwe/test:requirements-docker"
+        image: resolwe/test:requirements-docker
   output:
     - name: result
       label: Result
@@ -415,7 +415,7 @@
   requirements:
     executor:
       docker:
-        image: "resolwe/test:base"
+        image: resolwe/test:base
     resources:
       network: true
   run:

--- a/resolwe/toolkit/processes/archiver.yml
+++ b/resolwe/toolkit/processes/archiver.yml
@@ -5,7 +5,7 @@
     expression-engine: jinja
     executor:
       docker:
-        image: "resolwe/archiver"
+        image: resolwe/archiver
   version: 0.0.1
   type: "data:archive:"
   category: other

--- a/resolwe/toolkit/processes/files.yml
+++ b/resolwe/toolkit/processes/files.yml
@@ -9,7 +9,7 @@
     expression-engine: jinja
     executor:
       docker:
-        image: "resolwe/base:fedora-26"
+        image: resolwe/base:fedora-26
   data_name: '{{ src.file|default("?") }}'
   version: 0.0.4
   type: data:file
@@ -39,7 +39,7 @@
     expression-engine: jinja
     executor:
       docker:
-        image: "resolwe/base:fedora-26"
+        image: resolwe/base:fedora-26
   data_name: '{{ src.file|default("?") }}'
   version: 0.0.4
   type: data:file:image
@@ -72,7 +72,7 @@
     expression-engine: jinja
     executor:
       docker:
-        image: "resolwe/upload-tab-file"
+        image: resolwe/upload-tab-file
   data_name: '{{ src.file|default("?") }}'
   version: 0.0.3
   type: data:file:tab

--- a/resolwe/toolkit/processes/files.yml
+++ b/resolwe/toolkit/processes/files.yml
@@ -11,7 +11,7 @@
       docker:
         image: "resolwe/base:fedora-26"
   data_name: '{{ src.file|default("?") }}'
-  version: 0.0.3
+  version: 0.0.4
   type: data:file
   category: upload
   persistence: RAW
@@ -41,7 +41,7 @@
       docker:
         image: "resolwe/base:fedora-26"
   data_name: '{{ src.file|default("?") }}'
-  version: 0.0.3
+  version: 0.0.4
   type: data:file:image
   category: upload
   persistence: RAW


### PR DESCRIPTION
Remove redundant double-quotes when specifying Docker images


