### PR TITLE
Add additional tests for 'list_docker_images'

### DIFF
--- a/resolwe/flow/tests/processes/tests.yml
+++ b/resolwe/flow/tests/processes/tests.yml
@@ -467,3 +467,25 @@
     program: |
       echo "1a" >> storage.json
       re-save storage storage.json
+
+- slug: test-docker-image-versioning
+  name: Test process Docker image versioning
+  version: 1.0.1
+  type: "data:test:dockerversioning"
+  requirements:
+    executor:
+      docker:
+        image: resolwe/test:versioning-1
+  run:
+    program: "true"
+
+- slug: test-docker-image-versioning
+  name: Test process Docker image versioning
+  version: 1.0.2
+  type: "data:test:dockerversioning"
+  requirements:
+    executor:
+      docker:
+        image: resolwe/test:versioning-2
+  run:
+    program: "true"

--- a/resolwe/flow/tests/test_commands.py
+++ b/resolwe/flow/tests/test_commands.py
@@ -141,3 +141,21 @@ class ListDockerImagesTest(ProcessTestCase):
         self.assertTrue(len(imgs) != 0)
         self.assertTrue(isinstance(imgs[0], dict))
         self.assertTrue(dict(name='resolwe/test', tag='base') in imgs)
+
+    def test_list_is_sorted(self):
+        # The returned list must be sorted alphabetically
+        out, err = StringIO(), StringIO()
+        call_command('list_docker_images', stdout=out, stderr=err)
+        self.assertEqual('', err.getvalue())
+        self.assertNotEqual('', out.getvalue())
+        lines = out.getvalue().split('\n')[:-1]
+        self.assertEqual(lines, sorted(lines))
+
+    def test_list_versions(self):
+        # The returned list must contain only the Docker image from
+        # the latest version of a given process
+        out, err = StringIO(), StringIO()
+        call_command('list_docker_images', stdout=out, stderr=err)
+        self.assertEqual('', err.getvalue())
+        self.assertIn('resolwe/test:versioning-2', out.getvalue())
+        self.assertNotIn('resolwe/test:versioning-1', out.getvalue())


### PR DESCRIPTION
This commit adds two additional tests for the `list_docker_images`
management command.  It tests sorting of the output and proper handling
of process versions.