### PR TITLE
Use per-process upload dir in tests

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -22,6 +22,9 @@ Changed
 -------
 - **BACKWARD INCOMPATIBLE:** Run Docker containers as non-root user
 
+Fixed
+-----
+- Use per-process upload dir in tests to avoid race conditions
 
 ==================
 2.0.0 - 2017-08-24


### PR DESCRIPTION
Similar to already existing per-process data directories. My suspicion is that using the same upload directory in multiple parallel processes can cause race conditions in SELinux directory relabeling, which may cause containers to fail to start during tests.

In addition, this separation is also needed as otherwise there is another potential race condition when the same filename is used in two concurrent tests. In this case one test may see the upload disappear.