### PR TITLE
Relabel temporary user/group files

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -10,6 +10,10 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 Unreleased
 ==========
 
+Fixed
+-----
+- Correctly relabel SELinux contexts on user/group files
+
 
 ==================
 3.0.0 - 2017-09-13

--- a/resolwe/flow/executors/docker/__init__.py
+++ b/resolwe/flow/executors/docker/__init__.py
@@ -117,8 +117,8 @@ class FlowExecutor(LocalFlowExecutor):
         group_file.file.flush()
         self.temporary_files.append(group_file)
 
-        mappings.append({'src': passwd_file.name, 'dest': '/etc/passwd', 'mode': 'ro'})
-        mappings.append({'src': group_file.name, 'dest': '/etc/group', 'mode': 'ro'})
+        mappings.append({'src': passwd_file.name, 'dest': '/etc/passwd', 'mode': 'ro,Z'})
+        mappings.append({'src': group_file.name, 'dest': '/etc/group', 'mode': 'ro,Z'})
 
         # create mappings for tools
         # NOTE: To prevent processes tampering with tools, all tools are mounted read-only

--- a/resolwe/flow/tests/processes/tests.yml
+++ b/resolwe/flow/tests/processes/tests.yml
@@ -489,3 +489,24 @@
         image: resolwe/test:versioning-2
   run:
     program: "true"
+
+- slug: test-docker-uid-gid
+  name: Minimalistic Processor
+  version: 1.0.0
+  type: "data:test:min"
+  output:
+    - name: result
+      label: Result
+      type: basic:string
+  run:
+    program: |
+      # Check if we are running as non-root.
+      if [[ $UID == 0 || $GID == 0 ]]; then
+        echo '{"result": "ERROR: Running as root."}'
+      else
+        echo '{"result": "OK"}'
+      fi
+
+      # Ensure that we can resolve both our user and group names.
+      getent passwd $UID || exit 1
+      getent group $GID || exit 1

--- a/resolwe/flow/tests/test_executors.py
+++ b/resolwe/flow/tests/test_executors.py
@@ -160,6 +160,11 @@ class ManagerRunProcessTest(ProcessTestCase):
         data = self.run_process('test-requirements-docker')
         self.assertEqual(data.output['result'], 'OK')
 
+    @with_docker_executor
+    def test_docker_uid_gid(self):
+        data = self.run_process('test-docker-uid-gid')
+        self.assertEqual(data.output['result'], 'OK')
+
     @with_null_executor
     def test_null_executor(self):
         data = self.run_process('test-save-number', {'number': 19}, assert_status=Data.STATUS_WAITING)


### PR DESCRIPTION
For some reason this wasn't caught by tests, but later caused problems with iClip tests on Jenkins with SELinux enabled.

This should probably be backported to 3.x.