### PR TITLE
Add current_user_permissions to serializer's fields

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -10,6 +10,11 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 Unreleased
 ==========
 
+Fixed
+-----
+- Serialize ``current_user_permissions`` field in a way that is 
+  compatible with DRF 3.6.4+
+
 
 ==================
 3.0.1 - 2017-09-15


### PR DESCRIPTION
Broken because of https://github.com/encode/django-rest-framework/commit/b905197f24a74066e79888c56ddcf676c994cefc#diff-acb883ee0c042314f361a94aa00e5424