### PR TITLE
Pull Docker images after process registration is complete

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -14,6 +14,11 @@ Added
 -----
 - ``resolwe/base`` Docker image based on Ubuntu 17.04
 - Support different dependency kinds between data objects
+- ``--pull`` option to the ``list_docker_images`` management command
+
+Changed
+-------
+- Pull Docker images after process registration is complete
 
 Fixed
 -----

--- a/resolwe/flow/executors/__init__.py
+++ b/resolwe/flow/executors/__init__.py
@@ -381,3 +381,11 @@ class BaseFlowExecutor(BaseEngine):
     def terminate(self, data_id):
         """Terminate a running script."""
         raise NotImplementedError('subclasses of BaseFlowExecutor may require a terminate() method')
+
+    def post_register_hook(self):
+        """Run hook after the 'register' management command finishes.
+
+        Subclasses may implement this hook to e.g. pull Docker images at this point.
+        By default, it does nothing.
+        """
+        pass

--- a/resolwe/flow/executors/docker/__init__.py
+++ b/resolwe/flow/executors/docker/__init__.py
@@ -8,6 +8,7 @@ import subprocess
 import tempfile
 
 from django.conf import settings
+from django.core.management import call_command
 
 from resolwe.flow.models import Process
 
@@ -183,3 +184,8 @@ class FlowExecutor(LocalFlowExecutor):
     def terminate(self, data_id):
         """Terminate a running script."""
         subprocess.call(shlex.split('{} rm -f {}'.format(self.command, data_id)))
+
+    def post_register_hook(self):
+        """Pull Docker images required by processes after the 'register' command is done."""
+        if not getattr(settings, 'FLOW_DOCKER_DONT_PULL', False):
+            call_command('list_docker_images', pull=True)

--- a/resolwe/flow/management/commands/register.py
+++ b/resolwe/flow/management/commands/register.py
@@ -320,3 +320,6 @@ class Command(BaseCommand):
                 self.find_schemas(desc_path, filters=schemas, schema_type='descriptor', verbosity=verbosity))
 
         self.register_descriptors(descriptor_schemas, user_admin, force, verbosity=verbosity)
+
+        self.stdout.write("Running executor post-registration hook...")
+        manager.get_executor().post_register_hook()

--- a/resolwe/test/utils.py
+++ b/resolwe/test/utils.py
@@ -92,6 +92,9 @@ def with_custom_executor(wrapped=None, **custom_executor_settings):
                 # Re-run engine discovery as the settings have changed.
                 manager.discover_engines()
 
+                # Re-run the post_register_hook
+                manager.get_executor().post_register_hook()
+
                 # Run the actual unit test method.
                 return wrapped_method(*args, **kwargs)
         finally:

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -102,6 +102,12 @@ FLOW_EXECUTOR = {
 if 'RESOLWE_DOCKER_COMMAND' in os.environ:
     FLOW_DOCKER_COMMAND = os.environ['RESOLWE_DOCKER_COMMAND']
 
+# Ignore errors when pulling Docker images from 'list_docker_images --pull' command.
+FLOW_DOCKER_IGNORE_PULL_ERRORS = strtobool(os.environ.get('RESOLWE_DOCKER_IGNORE_PULL_ERRORS', '1'))
+
+# Don't pull Docker images if set via the environment variable.
+FLOW_DOCKER_DONT_PULL = strtobool(os.environ.get('RESOLWE_DOCKER_DONT_PULL', '0'))
+
 # Disable SECCOMP if set via environment variable.
 FLOW_DOCKER_DISABLE_SECCOMP = strtobool(os.environ.get('RESOLWE_DOCKER_DISABLE_SECCOMP', '0'))
 


### PR DESCRIPTION
This PR adds the `--pull` option to the `list_docker_images` management command, as well as a `post_register_hook` to the `BaseFlowExecutor` class, which is called by the `register` command after process registration finishes.  This hook is implemented by the Docker executor to pull Docker images.

The WIP part: in its current state, it should work in production, but the tests use the local executor and override it for Docker tests, so the hook is never run.  Working on fixing this at the moment.