### PR TITLE
Make ProcessTestCase non-transactional

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -23,6 +23,7 @@ Added
 Changed
 -------
 - **BACKWARD INCOMPATIBLE:** Bump Django requirement to version 1.11.x
+- **BACKWARD INCOMPATIBLE:** Make ``ProcessTestCase`` non-transactional
 - Pull Docker images after process registration is complete
 - Generalize jinja filters to accept lists of data objects
 

--- a/resolwe/flow/tests/test_access_api.py
+++ b/resolwe/flow/tests/test_access_api.py
@@ -10,10 +10,10 @@ from django.test import LiveServerTestCase
 from guardian.shortcuts import assign_perm
 
 from resolwe.flow.models import Collection, Process, Storage
-from resolwe.test import TransactionProcessTestCase, check_installed, with_docker_executor, with_resolwe_host
+from resolwe.test import ProcessTestCase, check_installed, with_docker_executor, with_resolwe_host
 
 
-class AccessAPIFromExecutorProcessTestCase(TransactionProcessTestCase, LiveServerTestCase):
+class AccessAPIFromExecutorProcessTestCase(ProcessTestCase, LiveServerTestCase):
 
     def _create_collection(self):
         """Create a test collection that will be accessed via a test process.
@@ -70,7 +70,7 @@ echo "{\"collection-list\": $(curl --silent --show-error $RESOLWE_HOST_URL/colle
         return process
 
     def setUp(self):
-        """Custom initilization of :class:`~TransactionProcessTestCase`."""
+        """Custom initilization of :class:`~ProcessTestCase`."""
         super(AccessAPIFromExecutorProcessTestCase, self).setUp()
 
         self.process = self.create_process()

--- a/resolwe/flow/tests/test_manager.py
+++ b/resolwe/flow/tests/test_manager.py
@@ -8,15 +8,12 @@ from django.db import transaction
 from guardian.shortcuts import assign_perm
 
 from resolwe.flow.models import Collection, Data, DataDependency, DescriptorSchema, Process
-from resolwe.test import TransactionProcessTestCase
+from resolwe.test import ProcessTestCase
 
 PROCESSES_DIR = os.path.join(os.path.dirname(__file__), 'processes')
 
 
-# NOTE: Manager is triggered on the commit of the transaction. Because
-#       of this it should be tested in TransactionTestCase, as it won't
-#       be triggered if whole test is wrapped in a transaction.
-class TestManager(TransactionProcessTestCase):
+class TestManager(ProcessTestCase):
 
     def setUp(self):
         super(TestManager, self).setUp()

--- a/resolwe/test/__init__.py
+++ b/resolwe/test/__init__.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from resolwe.test.testcases import TestCase, TestCaseHelpers, TransactionTestCase
 from resolwe.test.testcases.api import ResolweAPITestCase
 from resolwe.test.testcases.elastic import ElasticSearchTestCase, TransactionElasticSearchTestCase
-from resolwe.test.testcases.process import ProcessTestCase, TransactionProcessTestCase
+from resolwe.test.testcases.process import ProcessTestCase
 from resolwe.test.utils import (
     check_docker, check_installed, has_process_tag, tag_process, with_custom_executor, with_docker_executor,
     with_null_executor, with_resolwe_host,
@@ -25,7 +25,7 @@ __all__ = (
     'TestCase', 'TestCaseHelpers', 'TransactionTestCase',
     'ResolweAPITestCase',
     'ElasticSearchTestCase', 'TransactionElasticSearchTestCase',
-    'ProcessTestCase', 'TransactionProcessTestCase',
+    'ProcessTestCase',
     'check_docker', 'check_installed', 'with_custom_executor', 'with_docker_executor',
     'with_null_executor', 'with_resolwe_host', 'tag_process', 'has_process_tag',
 )

--- a/resolwe/test/testcases/process.py
+++ b/resolwe/test/testcases/process.py
@@ -21,7 +21,6 @@ import zipfile
 from six.moves import filterfalse
 
 from django.conf import settings
-from django.contrib.contenttypes.models import ContentType
 from django.core import management
 from django.db import transaction
 from django.test import override_settings
@@ -206,13 +205,6 @@ class ProcessTestCase(TransactionTestCase):
             name="Test collection",
             contributor=self.admin,
         )
-
-    def _pre_setup(self, *args, **kwargs):
-        # NOTE: This is a work-around for Django issue #10827
-        # (https://code.djangoproject.com/ticket/10827) that clears the
-        # ContentType cache before permissions are setup.
-        ContentType.objects.clear_cache()
-        super(ProcessTestCase, self)._pre_setup(*args, **kwargs)
 
     def setUp(self):
         """Initialize test data."""


### PR DESCRIPTION
Remove `ProcessTestCase` that enclosed tests' code in a transaction and rename the non-transactional `TrasactionProcessTestCase` to `ProcessTestCase`.
Remove `ProcessTestCase.run_process`' `run_manager` argument since it no longer applies.
Update `test_executors.ManagerRunProcessTest.test_workflow` test to make it work with non-transactional `ProcessTestCase`.