### PR TITLE
Drop Python 2 support, require Python 3.4+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,6 @@ env:
 # NOTE: Explicit Python versions make Travis job description more informative
 matrix:
   include:
-    - env: TOX_ENV=py27
-      python: "2.7"
     - env: TOX_ENV=py34
       python: "3.4"
     - env: TOX_ENV=py35

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -10,6 +10,10 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 Unreleased
 ==========
 
+Changed
+-------
+- **BACKWARD INCOMPATIBLE:** Drop Python 2 support, require Python 3.4+
+
 
 ==================
 4.0.0 - 2017-10-25

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -5,8 +5,8 @@ Contributing
 Installing prerequisites
 ========================
 
-Make sure you have Python_ (2.7 or 3.4+) installed on your system. If you don't
-have it yet, follow `these instructions
+Make sure you have Python_ (3.4+) installed on your system. If you don't have
+it yet, follow `these instructions
 <https://docs.python.org/3/using/index.html>`__.
 
 Resolwe requires PostgreSQL_ (9.4+). Many Linux distributions already include
@@ -56,9 +56,8 @@ Prepare Resolwe for development::
 
 .. note::
 
-    We recommend using `virtualenv <https://virtualenv.pypa.io/>`_ (on
-    Python 2.7) or `pyvenv <http://docs.python.org/3/library/venv.html>`_ (on
-    Python 3.4+) to create an isolated Python environment for Resolwe.
+    We recommend using `pyvenv <http://docs.python.org/3/library/venv.html>`_
+    to create an isolated Python environment for Resolwe.
 
 .. _Resolwe's git repository: https://github.com/genialis/resolwe
 

--- a/resolwe/flow/models/data.py
+++ b/resolwe/flow/models/data.py
@@ -25,7 +25,7 @@ from .utils import (
     DirtyError, hydrate_input_references, hydrate_size, render_descriptor, render_template, validate_schema,
 )
 
-# Compat between Python 2.7/3.4 and Python 3.5
+# Compatibilty for Python < 3.5.
 if not hasattr(json, 'JSONDecodeError'):
     json.JSONDecodeError = ValueError
 

--- a/resolwe/flow/models/utils.py
+++ b/resolwe/flow/models/utils.py
@@ -15,9 +15,8 @@ from django.core.exceptions import ValidationError
 
 from resolwe.flow.utils import dict_dot, iterate_fields, iterate_schema
 
-# TODO: Python 3.5 imports modules in a different (lazy) way, so when
-#       Python 2.7 and Python 3.4 support is dropped, data module can be
-#       imported as:
+# TODO: Python 3.5+ imports modules in a different (lazy) way, so when
+#       Python 3.4 support is dropped, data module can be imported as:
 #
 #           from . import data as data_model
 #

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,3 @@
-[bdist_wheel]
-# code is written to work on both Python 2 and Python 3
-universal = 1
-
 [pycodestyle]
 # Django coding style guidelines allow up to 119 characters
 max-line-length = 119

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup(
         # have to pin it
         'django-filter~=1.0.0',
     ],
+    python_requires='>=3.4, <3.6',
     extras_require={
         'docs':  [
             'sphinx_rtd_theme',
@@ -99,10 +100,6 @@ setup(
             'tblib>=1.3.0',
             'isort',
         ],
-        ':python_version == "2.7"': [
-            # Backport of shutil.which function to Python 2
-            'shutilwhich',
-        ]
     },
 
     classifiers=[
@@ -122,8 +119,6 @@ setup(
         'Operating System :: OS Independent',
 
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35},docs,linters,packaging,migrations
+envlist = py{34,35},docs,linters,packaging,migrations
 skip_missing_interpreters = True
 
 # NOTE: Don't use 'deps = .[<extra-requirements>]' tox option since we
@@ -25,6 +25,8 @@ commands =
 passenv = TOXENV RESOLWE_* DOCKER_* TRAVIS LC_*
 
 [testenv:docs]
+# ensure we run the tests with the latest supported Python version
+basepython = python3.5
 commands =
 # install documentation requirements
     pip install .[docs]
@@ -34,6 +36,8 @@ commands =
     python setup.py build_sphinx --fresh-env --warning-is-error
 
 [testenv:linters]
+# ensure we run the tests with the latest supported Python version
+basepython = python3.5
 # run all linters to see their output even if one of them fails
 ignore_errors = True
 commands =
@@ -51,6 +55,8 @@ commands =
     isort --recursive --check-only --diff resolwe
 
 [testenv:packaging]
+# ensure we run the tests with the latest supported Python version
+basepython = python3.5
 commands =
 # install testing requirements
     pip install .[test]
@@ -63,6 +69,8 @@ commands =
     python setup.py check --metadata --restructuredtext --strict
 
 [testenv:migrations]
+# ensure we run the tests with the latest supported Python version
+basepython = python3.5
 whitelist_externals =
     bash
     psql


### PR DESCRIPTION
Use `python_requires` `setup()` argument to specify the required Python version.