### PR TITLE
Fix race condition when scanning for resolving Data objects

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -22,6 +22,7 @@ Added
 
 Fixed
 -----
+- Fix ``Data`` object preparation race condition in ``communicate()``
 - Set correct executor in flow manager
 - Make executors more robust to unhandled failures
 - Calculate ``Data.size`` by summing ``total_size`` of all file-type outputs

--- a/resolwe/flow/managers/base.py
+++ b/resolwe/flow/managers/base.py
@@ -590,6 +590,9 @@ class BaseManager(object):
             discovered in this pass.
         """
         queue = []
+        # Announce this here so it's not defined in the loop first;
+        # if it is, the linter complains.
+        transaction_success = []
         logger.debug(__(
             "Manager '{}.{}' processing communicate command on '{}' for executor '{}'.",
             self.__class__.__module__,
@@ -605,6 +608,9 @@ class BaseManager(object):
             ContentType.objects.clear_cache()
         try:
             for data in Data.objects.filter(status=Data.STATUS_RESOLVING):
+                # Flag for transaction success. Can't be a primitive var
+                # due to closure semantics.
+                transaction_success = []
                 with transaction.atomic():
                     # Lock for update. Note that we want this transaction to be as short as
                     # possible in order to reduce contention and avoid deadlocks. This is
@@ -654,44 +660,52 @@ class BaseManager(object):
                         data.status = Data.STATUS_WAITING
                     data.save(render_name=True)
 
-                    if program is not None:
-                        try:
-                            priority = 'normal'
-                            if data.process.persistence == Process.PERSISTENCE_TEMP:
-                                # TODO: This should probably be removed.
-                                priority = 'high'
-                            if data.process.scheduling_class == Process.SCHEDULING_CLASS_INTERACTIVE:
-                                priority = 'high'
-
-                            program = self._include_environment_variables(program)
-
-                            data_dir = self._prepare_data_dir(data.id)
-                            executor_module, runtime_dir = self._prepare_executor(data.id, executor)
-                            self._prepare_context(data.id, data_dir, runtime_dir, verbosity=verbosity)
-                            self._prepare_script(runtime_dir, program)
-                            argv = [
-                                '/bin/bash',
-                                '-c',
-                                self.settings_actual.get('FLOW_EXECUTOR', {}).get('PYTHON', '/usr/bin/env python') +
-                                ' -m executors ' + executor_module
-                            ]
-                        except PermissionDenied as error:
-                            data.status = Data.STATUS_ERROR
-                            data.process_error.append("Permission denied for process: {}".format(error))
-                            data.save()
-                            continue
-                        except OSError as err:
-                            logger.error(__(
-                                "OSError occurred while preparing data {} (will skip): {}",
-                                data.id, err
-                            ))
-                            continue
-
-                        queue.append((data.id, priority, runtime_dir, argv))
+                    # Signal transaction success through the flag.
+                    transaction.on_commit(lambda: transaction_success.append(True))
 
                     # All data objects created by the execution engine are commited after this
                     # point and may be processed by other managers running in parallel. At the
-                    # same time, lock for the current data object is released.
+                    # same time, the lock for the current data object is released.
+
+                # End of the with clause
+
+                # If the transaction didn't roll back, we're good to go with adding the object
+                # to the processing queue. This shouldn't be in the transaction, since it
+                # wouldn't roll back in case the transaction failed.
+                if any(transaction_success) and program is not None:
+                    try:
+                        priority = 'normal'
+                        if data.process.persistence == Process.PERSISTENCE_TEMP:
+                            # TODO: This should probably be removed.
+                            priority = 'high'
+                        if data.process.scheduling_class == Process.SCHEDULING_CLASS_INTERACTIVE:
+                            priority = 'high'
+
+                        program = self._include_environment_variables(program)
+
+                        data_dir = self._prepare_data_dir(data.id)
+                        executor_module, runtime_dir = self._prepare_executor(data.id, executor)
+                        self._prepare_context(data.id, data_dir, runtime_dir, verbosity=verbosity)
+                        self._prepare_script(runtime_dir, program)
+                        argv = [
+                            '/bin/bash',
+                            '-c',
+                            self.settings_actual.get('FLOW_EXECUTOR', {}).get('PYTHON', '/usr/bin/env python') +
+                            ' -m executors ' + executor_module
+                        ]
+                    except PermissionDenied as error:
+                        data.status = Data.STATUS_ERROR
+                        data.process_error.append("Permission denied for process: {}".format(error))
+                        data.save()
+                        continue
+                    except OSError as err:
+                        logger.error(__(
+                            "OSError occurred while preparing data {} (will skip): {}",
+                            data.id, err
+                        ))
+                        continue
+
+                    queue.append((data.id, priority, runtime_dir, argv))
 
         except IntegrityError as exp:
             logger.error(__("IntegrityError in manager {}", exp))


### PR DESCRIPTION
Suppose two manager instances scan the database at roughly the same
time and enter the checking transaction for the same object. Both get to
the end of the transaction at the same time, having checked that the
object is indeed resolving. Both also add it to their own to-do queues
before exiting the transaction. At the end, exactly one of the
transactions will succeed, because they both affect the same rows, so
the other will roll back, however: the object will still stay in that
manager's queue. This means that both managers will proceed to try to
execute this Data object, even though one of them actually had a failed
status update transaction.

The fix is to make adding to the queue dependent on transaction success
by setting a flag in its transaction.on_commit event.