### PR TITLE
Change test directory creation so it always creates a subdirectory

### DIFF
--- a/resolwe/test_helpers/test_runner.py
+++ b/resolwe/test_helpers/test_runner.py
@@ -174,8 +174,7 @@ def _sequence_paths(paths):
         created = []
 
         for base_path in paths:
-            head, tail = os.path.split(base_path)
-            path = os.path.join(head, '{}_{}'.format(tail, seq))
+            path = os.path.join(base_path, 'test_{}'.format(seq))
             try:
                 os.makedirs(path)
                 created.append(path)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -117,11 +117,6 @@ FLOW_EXECUTOR = {
     'UPLOAD_DIR': os.path.join(PROJECT_ROOT, '.test_upload'),
     'RUNTIME_DIR': os.path.join(PROJECT_ROOT, '.test_runtime'),
     'REDIS_CONNECTION': REDIS_CONNECTION,
-    'TEST': {
-        'DATA_DIR': os.path.join(PROJECT_ROOT, '.test_data/test'),
-        'UPLOAD_DIR': os.path.join(PROJECT_ROOT, '.test_upload/test'),
-        'RUNTIME_DIR': os.path.join(PROJECT_ROOT, '.test_runtime/test'),
-    },
 }
 
 FLOW_MANAGER = {


### PR DESCRIPTION
The post-channelization system was to merely append a suffix to the
settings in FLOW_EXECUTOR, so e.g. `test_data/test` was transformed into
`test_data/test_<num>`. If there were no special test settings, e.g.
`resolwe_data/`, this was therefore changed into `resolwe_data_<num>/`,
which is jarring. The new code creates `[setting]/test_<num>`
directories, so there are no weird top-level suffixed siblings.