### PR TITLE
Remove redundant setting of Tox's extras configuration option

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,6 @@ commands =
 [testenv:linters]
 # ensure we run the tests with the latest supported Python version
 basepython = python3.5
-extras = test
 # run all linters to see their output even if one of them fails
 ignore_errors = True
 commands =
@@ -51,7 +50,6 @@ commands =
 [testenv:packaging]
 # ensure we run the tests with the latest supported Python version
 basepython = python3.5
-extras = test
 commands =
 # verify installed packages have compatible dependencies
     pip check


### PR DESCRIPTION
Tox environments inherit configuration options from their parents so it is not necessary to define a configuration option in a child environment if its value is the same as in its parent environment.