### PR TITLE
Switch Docker base image from Ubuntu 17.04 to Ubuntu 17.10

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -10,6 +10,17 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 Unreleased
 ==========
 
+Changed
+-------
+
+- **BACKWARD INCOMPATIBLE:** Remove Ubuntu 17.04 base Docker image due to end
+  of lifetime
+
+Added
+-----
+
+- Add Ubuntu 17.10 base Docker image
+
 
 ==================
 6.0.0 - 2018-01-17

--- a/resolwe/toolkit/docker_images/base/Dockerfile.ubuntu-17.10
+++ b/resolwe/toolkit/docker_images/base/Dockerfile.ubuntu-17.10
@@ -1,4 +1,4 @@
-FROM docker.io/ubuntu:17.04
+FROM docker.io/ubuntu:17.10
 
 LABEL MAINTAINER Resolwe authors https://github.com/genialis/resolwe
 

--- a/resolwe/toolkit/docker_images/base/README.md
+++ b/resolwe/toolkit/docker_images/base/README.md
@@ -5,10 +5,10 @@ http://resolwe-runtime-utils.readthedocs.io).
 
 The `fedora-26` image is based on [`docker.io/fedora:26`](
 https://hub.docker.com/_/fedora/).
-The `ubuntu-14.04`, `ubuntu-16.04`, `ubuntu-17.04` images are based on
+The `ubuntu-14.04`, `ubuntu-16.04`, `ubuntu-17.10` images are based on
 [`docker.io/ubuntu:14.04`](https://hub.docker.com/_/ubuntu/),
 [`docker.io/ubuntu:16.04`](https://hub.docker.com/_/ubuntu/) and
-[`docker.io/ubuntu:17.04`](https://hub.docker.com/_/ubuntu/)
+[`docker.io/ubuntu:17.10`](https://hub.docker.com/_/ubuntu/)
 respectively.
 
 The base images are used as bases for all the other


### PR DESCRIPTION
Ubuntu 17.04 reached end of life on 13. 1. 2018, so it is removed from
base images and Ubuntu 17.10 is added instead.