### PR TITLE
Enable manager prefix overriding from the env

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -16,6 +16,8 @@ Changed
   of lifetime
 - **BACKWARD INCOMPATIBLE:** Remove support for Jinja in ``DescriptorSchema``'s
   default values
+- Add mechanism to change test database name from the environment, appending
+  a ``_test`` suffix to it; this replaces the static name used before
 
 Added
 -----

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -32,6 +32,8 @@ Fixed
   ``Data.process_info`` cannot be overwritten
 - Handle missing ``Data`` objects in ``hydrate_input_references`` function
 - Make parallel test suite worker threads clean up after initialization failures
+- Add mechanism to override the manager's control channel prefix from the
+  environment
 
 
 ==================

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -83,7 +83,7 @@ DATABASES = {
         'HOST': pghost,
         'PORT': pgport,
         'TEST': {
-            'NAME': 'resolwe_test' + toxenv
+            'NAME': pgname + '_test'
         }
     }
 }

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -119,11 +119,13 @@ FLOW_EXECUTOR = {
     'REDIS_CONNECTION': REDIS_CONNECTION,
 }
 
+# Check if any Manager settings are set via environment variables
+manager_prefix = os.environ.get('RESOLWE_MANAGER_REDIS_PREFIX', 'resolwe.flow.manager')
 FLOW_MANAGER = {
-    'REDIS_PREFIX': 'resolwe.flow.manager',
+    'REDIS_PREFIX': manager_prefix,
     'REDIS_CONNECTION': REDIS_CONNECTION,
     'TEST': {
-        'REDIS_PREFIX': 'resolwe.flow.manager-test',
+        'REDIS_PREFIX': manager_prefix + '-test',
     },
 }
 


### PR DESCRIPTION
Enable manager prefix overriding from the environment, in case someone wants to run multiple instances of the test suite at once.