### PR TITLE
Mitigate parallel test suite startup failure effects

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -31,6 +31,7 @@ Fixed
 - Make sure values in ``Data.process_error``, ``Data.process_warning`` and
   ``Data.process_info`` cannot be overwritten
 - Handle missing ``Data`` objects in ``hydrate_input_references`` function
+- Make parallel test suite worker threads clean up after initialization failures
 
 
 ==================


### PR DESCRIPTION
In case worker initialization fails for any reason, Python's
multiprocessing pool will just keep restarting workers until the pool
fills up. Due to operation ordering in our test runner, this resulted in
test directories being created in what was effectively an infinite loop.

Example: a mistyped import in routing.py. During init, the manager is
asked to drain its control channel. The drain function calls one of the
testing methods in Django Channels, which will then lazily initialize
the backend - and fail. The resulting exception will propagate up the
stack into the multiprocessing module where it will cause worker failure
(early bootstrap immediately calls os._exit() if there are exceptions).
Because there is still work to be done, new workers will be spawned and
the process repeats ad nauseam.

Because our customized init creates test directories before requesting
channel drainage, this results in an unbounded accumulation of empty
directories on the filesystem.

An obvious fix is to just move directory creation downstream from
the channel drain call, but this is suboptimal as it introduces an
ordering requirement in two disparate pieces of code while also being a
very specialized fix (to handle routing initialization errors).

Logically, directory creation modifies the configuration space of the
process. These changes should be committed before code that needs them
(the manager's drain call) is called. This currently isn't the case in
actual code (drainage only requires Redis settings, not anything related
to paths), but reordering init would imply that manager setup must _not_
depend on any settings other than channels, which seems unreasonable.

Ideally, the proper fix would be to have a mechanism of telling the
worker pool that init simply will never succeed and that the entire show
should be killed. Because this isn't feasible, the alternative is merely
to do damage control: keep the operation ordering, as explained above,
but at least make sure we're not leaking resources if there's a failure
after directory creation is done. If the init function fails, code after
it will likely also fail, which will lead to an orderly shutdown
eventually.