### PR TITLE
Use filesystem-level lock for the data directory

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -36,6 +36,7 @@ Fixed
 - Make parallel test suite worker threads clean up after initialization failures
 - Add mechanism to override the manager's control channel prefix from the
   environment
+- Make executor fail early when executed twice on the same data directory
 
 
 ==================

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -18,6 +18,8 @@ Changed
   default values
 - Add mechanism to change test database name from the environment, appending
   a ``_test`` suffix to it; this replaces the static name used before
+- Remove runtime directory during general data purge instead of immediately after
+  each process finishes
 
 Added
 -----

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -25,6 +25,8 @@ Added
 -----
 - Add Ubuntu 17.10 base Docker image
 - Add ``descriptor_completed`` field to the ``Entity`` filter
+- Validate manager semaphors after each test case, to ease debugging of tests
+  which execute processes
 
 Fixed
 -----

--- a/resolwe/flow/executors/run.py
+++ b/resolwe/flow/executors/run.py
@@ -172,6 +172,11 @@ class BaseFlowExecutor(object):
         # The response channel (Redis list) is deleted automatically once the list is drained, so
         # there is no need to remove it manually.
 
+    def _create_file(self, filename):
+        """Ensure a new file is created and opened for writing."""
+        file_descriptor = os.open(filename, os.O_WRONLY | os.O_CREAT | os.O_EXCL)
+        return os.fdopen(file_descriptor, 'w')
+
     def _run(self, data_id, script, verbosity=1):
         """Execute the script and save results."""
         if verbosity >= 1:
@@ -186,8 +191,8 @@ class BaseFlowExecutor(object):
         self.resources = requirements.get('resources', {})
 
         os.chdir(EXECUTOR_SETTINGS['DATA_DIR'])
-        log_file = open('stdout.txt', 'w+')
-        json_file = open('jsonout.txt', 'w+')
+        log_file = self._create_file('stdout.txt')
+        json_file = self._create_file('jsonout.txt')
 
         proc_pid = self.start()
 

--- a/resolwe/flow/managers/dispatcher.py
+++ b/resolwe/flow/managers/dispatcher.py
@@ -497,7 +497,14 @@ class Manager(object):
                                 os.chmod(path, 0o700)
                                 shutil.rmtree(path)
 
-                        shutil.rmtree(self._get_per_data_dir('RUNTIME_DIR', data_id), onerror=handle_error)
+                        # Remove secrets directory, but leave the rest of the runtime directory
+                        # intact. Runtime directory will be removed during data purge, when the
+                        # data object is removed.
+                        secrets_dir = os.path.join(
+                            self._get_per_data_dir('RUNTIME_DIR', data_id),
+                            ExecutorFiles.SECRETS_DIR
+                        )
+                        shutil.rmtree(secrets_dir, onerror=handle_error)
                     except OSError:
                         logger.exception("Manager exception while removing data runtime directory.")
 

--- a/resolwe/flow/utils/purge.py
+++ b/resolwe/flow/utils/purge.py
@@ -103,6 +103,7 @@ def data_purge(data_ids=None, delete=False, verbosity=0):
 
     """
     data_path = settings.FLOW_EXECUTOR['DATA_DIR']
+    runtime_path = settings.FLOW_EXECUTOR['RUNTIME_DIR']
     unreferenced_files = set()
 
     data_qs = Data.objects.filter(status__in=[Data.STATUS_DONE, Data.STATUS_ERROR])
@@ -122,19 +123,20 @@ def data_purge(data_ids=None, delete=False, verbosity=0):
 
     # Remove any folders, which do not belong to any data objects.
     if data_ids is None:
-        for directory in os.listdir(data_path):
-            directory_path = os.path.join(data_path, directory)
-            if not os.path.isdir(directory_path):
-                continue
+        for base_path in (data_path, runtime_path):
+            for directory in os.listdir(base_path):
+                directory_path = os.path.join(base_path, directory)
+                if not os.path.isdir(directory_path):
+                    continue
 
-            try:
-                data_id = int(directory)
-            except ValueError:
-                continue
+                try:
+                    data_id = int(directory)
+                except ValueError:
+                    continue
 
-            # Check if a data object with the given identifier exists.
-            if not Data.objects.filter(pk=data_id).exists():
-                unreferenced_files.add(directory_path)
+                # Check if a data object with the given identifier exists.
+                if not Data.objects.filter(pk=data_id).exists():
+                    unreferenced_files.add(directory_path)
 
     if verbosity >= 1:
         # Print unreferenced files

--- a/resolwe/test_helpers/test_runner.py
+++ b/resolwe/test_helpers/test_runner.py
@@ -368,6 +368,33 @@ class ResolweRunner(DiscoverRunner):
         # while keeping suite.processes unchanged. We need to propagate the change here to
         # avoid spawning more processes than there are databases.
         suite.processes = self.parallel
+
+        # Augment all test cases with manager state validation logic.
+        def validate_manager_state(case, teardown):
+            """Decorate test case with manager state validation."""
+            def wrapper(*args, **kwargs):
+                """Validate manager state on teardown."""
+                if int(manager.state.executor_count) != 0 or int(manager.state.sync_semaphore) != 0:
+                    case.fail(
+                        'Test has outstanding manager processes. Ensure that all processes have '
+                        'completed or that you have reset the state manually in case you have '
+                        'bypassed the regular manager flow in any way.\n'
+                        '\n'
+                        'Executor count: {executor_count} (should be 0)\n'
+                        'Sync semaphore: {sync_semaphore} (should be 0)\n'
+                        ''.format(
+                            executor_count=int(manager.state.executor_count),
+                            sync_semaphore=int(manager.state.sync_semaphore),
+                        )
+                    )
+
+                teardown(*args, **kwargs)
+
+            return wrapper
+
+        for case in suite:
+            case.tearDown = validate_manager_state(case, case.tearDown)
+
         return suite
 
     def run_suite(self, suite, **kwargs):


### PR DESCRIPTION
This prevents the executor from being run twice on the same data directory. In this case, the second executor will abort.