### PR TITLE
Container image changes

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -16,6 +16,10 @@ Changed
   of lifetime
 - **BACKWARD INCOMPATIBLE:** Remove support for Jinja in ``DescriptorSchema``'s
   default values
+- **BACKWARD INCOMPATIBLE:** Remove ``CONTAINER_IMAGE`` configuration option
+  from the Docker executor; if no container image is specified for a process
+  using the Docker executor, the same pre-defined default image is used
+  (currently this is ``resolwe/base:ubuntu-16.04``)
 - Add mechanism to change test database name from the environment, appending
   a ``_test`` suffix to it; this replaces the static name used before
 

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -31,6 +31,8 @@ Added
   to Django's extreme memory usage when deleting a large count of ``Data`` objects
 - Add ``validate_process_types`` utility function, which checks that all registered
   processes conform to their supertypes
+- Add ``FLOW_CONTAINER_VALIDATE_IMAGE`` setting which can be used to validate
+  container image names
 
 Fixed
 -----

--- a/resolwe/flow/executors/docker/constants.py
+++ b/resolwe/flow/executors/docker/constants.py
@@ -3,3 +3,6 @@ DATA_VOLUME = '/data'
 DATA_ALL_VOLUME = '/data_all'
 UPLOAD_VOLUME = '/upload'
 SECRETS_VOLUME = '/secrets'
+
+# Container image used if no image is specified.
+DEFAULT_CONTAINER_IMAGE = 'resolwe/base:ubuntu-16.04'

--- a/resolwe/flow/executors/docker/run.py
+++ b/resolwe/flow/executors/docker/run.py
@@ -33,7 +33,7 @@ class FlowExecutor(LocalFlowExecutor):
         # arguments passed to the Docker command
         command_args = {
             'command': self.command,
-            'container_image': self.requirements.get('image', SETTINGS['FLOW_EXECUTOR']['CONTAINER_IMAGE']),
+            'container_image': self.requirements.get('image', constants.DEFAULT_CONTAINER_IMAGE),
         }
 
         # Get limit defaults.

--- a/resolwe/flow/management/commands/list_docker_images.py
+++ b/resolwe/flow/management/commands/list_docker_images.py
@@ -17,6 +17,7 @@ import yaml
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 
+from resolwe.flow.executors.docker.constants import DEFAULT_CONTAINER_IMAGE
 from resolwe.flow.models import Process
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -62,12 +63,8 @@ class Command(BaseCommand):
             if 'image' in p.requirements.get('executor', {}).get('docker', {})
         )
 
-        # Add the default image if it exists
-        if 'CONTAINER_IMAGE' in settings.FLOW_EXECUTOR:
-            # This Docker image is used if a process doesn't specify its own
-            default_docker_image = settings.FLOW_EXECUTOR['CONTAINER_IMAGE']
-
-            unique_docker_images.add(default_docker_image)
+        # Add the default image.
+        unique_docker_images.add(DEFAULT_CONTAINER_IMAGE)
 
         # Sort the set of unique Docker images for nicer output
         unique_docker_images = sorted(unique_docker_images)

--- a/resolwe/test/utils.py
+++ b/resolwe/test/utils.py
@@ -107,15 +107,10 @@ def with_custom_executor(wrapped=None, **custom_executor_settings):
     return wrapper(wrapped)  # pylint: disable=no-value-for-parameter
 
 
-def with_docker_executor(wrapped=None, image='resolwe/base:fedora-26'):
-    """Decorate unit test to run processes with the Docker executor.
-
-    :param str image: custom Docker image to use when running the Docker
-        executor
-
-    """
+def with_docker_executor(wrapped=None):
+    """Decorate unit test to run processes with the Docker executor."""
     if wrapped is None:
-        return functools.partial(with_docker_executor, image=image)
+        return functools.partial(with_docker_executor)
 
     # pylint: disable=missing-docstring
     @wrapt.decorator
@@ -123,7 +118,6 @@ def with_docker_executor(wrapped=None, image='resolwe/base:fedora-26'):
         return unittest.skipUnless(*check_docker())(
             with_custom_executor(
                 NAME='resolwe.flow.executors.docker',
-                CONTAINER_IMAGE=image,
             )(wrapped_method)
         )(*args, **kwargs)
 

--- a/resolwe/toolkit/processes/archiver.yml
+++ b/resolwe/toolkit/processes/archiver.yml
@@ -5,7 +5,7 @@
     expression-engine: jinja
     executor:
       docker:
-        image: resolwe/archiver
+        image: resolwe/archiver:1.0.0
   version: 0.0.1
   type: "data:archive:"
   category: other

--- a/resolwe/toolkit/processes/files.yml
+++ b/resolwe/toolkit/processes/files.yml
@@ -72,7 +72,7 @@
     expression-engine: jinja
     executor:
       docker:
-        image: resolwe/upload-tab-file
+        image: resolwe/upload-tab-file:1.0.0
   data_name: '{{ src.file|default("?") }}'
   version: 0.0.3
   type: data:file:tab

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -142,6 +142,9 @@ FLOW_DOCKER_DONT_PULL = strtobool(os.environ.get('RESOLWE_DOCKER_DONT_PULL', '0'
 # Disable SECCOMP if set via environment variable.
 FLOW_DOCKER_DISABLE_SECCOMP = strtobool(os.environ.get('RESOLWE_DOCKER_DISABLE_SECCOMP', '0'))
 
+# Ensure all container images follow a specific format.
+FLOW_CONTAINER_VALIDATE_IMAGE = r'.+:(?!latest)'
+
 FLOW_API = {
     'PERMISSIONS': 'resolwe.permissions.permissions',
 }


### PR DESCRIPTION
Tests currently fail because `resolwe/archiver` and `resolwe/upload-tab-file` have no image tag specified (tag `latest` is no longer allowed). We should tag the images and update these processes, perhaps `1.0.0`?