### PR TITLE
Ensure logging messages in JSONFormater are instatiated to strings

### DIFF
--- a/docs/ref.rst
+++ b/docs/ref.rst
@@ -10,3 +10,5 @@ Reference
 .. automodule:: resolwe.flow.management
 .. automodule:: resolwe.elastic
 .. automodule:: resolwe.test
+.. automodule:: resolwe.utils
+   :members:

--- a/resolwe/flow/executors/logger.py
+++ b/resolwe/flow/executors/logger.py
@@ -26,6 +26,10 @@ class JSONFormatter(logging.Formatter):
         # Exception and Traceback cannot be serialized.
         data['exc_info'] = None
 
+        # Ensure logging message is instantiated to a string (it could a BraceMessage instance
+        # which is not JSON serializable).
+        data['msg'] = str(data['msg'])
+
         return json.dumps(data)
 
 

--- a/resolwe/utils.py
+++ b/resolwe/utils.py
@@ -1,20 +1,31 @@
-"""Utility functions."""
+""".. Ignore pydocstyle D400.
+
+=================
+Resolwe Utilities
+=================
+
+"""
 
 
 class BraceMessage(object):
     """Log messages with the new {}-string formatting syntax.
 
-    NOTE: When using this helper class, one pays no signigicant
-    performance penalty since the actual formatting only happens when
-    (and if) the logged message is actually outputted to a log by a
-    handler.
+    .. note::
+        When using this helper class, one pays no significant
+        performance penalty since the actual formatting only happens
+        when (and if) the logged message is actually outputted to a log
+        by a handler.
 
-    Example usage:
-    from genesis.utils.formatters import BraceMessage as __
-    logger.error(__("Message with {0} {name}", 2, name="placeholders"))
+    Example of usage:
+
+        .. code-block:: python
+
+            from resolwe.utils import BraceMessage as __
+
+            logger.error(__("Message with {0} {name}", 2, name="placeholders"))
 
     Source:
-    https://docs.python.org/3/howto/logging-cookbook.html#use-of-alternative-formatting-styles
+    https://docs.python.org/3/howto/logging-cookbook.html#use-of-alternative-formatting-styles.
 
     """
 


### PR DESCRIPTION
In addition, prettify `BraceMessage`'s docstring and include Resolwe Utilities in the documentation reference.