### PR TITLE
Improve Docker Compose configuration for Elasticsearch

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -12,7 +12,18 @@ elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:5.6.8
     environment:
         - discovery.type=single-node
+        # Limit JVM's heap memory.
+        - ES_JAVA_OPTS=-Xms512m -Xmx512m
+        # Disable X-Pack included in the official images.
+        - xpack.graph.enabled=false
+        - xpack.ml.enabled=false
+        - xpack.monitoring.enabled=false
+        # NOTE: Elasticsearch complains about unknown setting even though it is
+        # documented at:
+        # https://www.elastic.co/guide/en/x-pack/5.6/installing-xpack.html#xpack-enabling
+        # - xpack.reporting.enabled=false
         - xpack.security.enabled=false
+        - xpack.watcher.enabled=false
     ports:
         - "59200:9200"
 redis:


### PR DESCRIPTION
This should lower the resources used by the Elasticsearch container.