### PR TITLE
Lazily create ES mappings on first push

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -18,6 +18,7 @@ Changed
 - **BACKWARD INCOMPATIBLE:** Switch ``Data`` API viewset to use Elasticsearch
 - Terminate the executor if listener response with error message
 - ``verbosity`` setting is no longer propagated to the executor
+- Only create Elasticsearch mappings on first push
 
 Added
 -----
@@ -29,6 +30,7 @@ Added
   ``DataSerializer``
 - Support lookup expressions (``lt``, ``lte``, ``gt``, ``gte``) in ES viewsets
 - Support for easier dynamic composition of type extensions
+- Add ``elastic_mapping`` management command
 
 Fixed
 -----

--- a/resolwe/elastic/builder.py
+++ b/resolwe/elastic/builder.py
@@ -368,7 +368,6 @@ class IndexBuilder(object):
         prepare_connection()
 
         self.discover_indexes()
-        self.create_mappings()
         self.register_signals()
 
     def _connect_signal(self, index):

--- a/resolwe/elastic/management/commands/__init__.py
+++ b/resolwe/elastic/management/commands/__init__.py
@@ -8,4 +8,8 @@ Elastic app includes following Django management commands:
 
 .. automodule:: resolwe.elastic.management.commands.elastic_index
 
+.. automodule:: resolwe.elastic.management.commands.elastic_mapping
+
+.. automodule:: resolwe.elastic.management.commands.elastic_purge
+
 """

--- a/resolwe/elastic/management/commands/elastic_mapping.py
+++ b/resolwe/elastic/management/commands/elastic_mapping.py
@@ -1,0 +1,31 @@
+""".. Ignore pydocstyle D400.
+
+========================
+Command: elastic_mapping
+========================
+
+"""
+from django.core.management.base import BaseCommand
+
+from resolwe.elastic.builder import index_builder
+from resolwe.elastic.mixins import ElasticIndexFilterMixin
+
+
+class Command(ElasticIndexFilterMixin, BaseCommand):
+    """Create ElasticSearch mappings."""
+
+    help = "Create ElasticSearch mappings."
+
+    def handle_index(self, index):
+        """Process index."""
+        index.create_mapping()
+
+    def handle(self, *args, **options):
+        """Command handle."""
+        verbosity = int(options['verbosity'])
+
+        if self.has_filter(options):
+            self.filter_indices(options, verbosity)
+        else:
+            # Process all indices.
+            index_builder.create_mappings()

--- a/resolwe/elastic/tests/test_index.py
+++ b/resolwe/elastic/tests/test_index.py
@@ -191,6 +191,9 @@ class IndexTest(ElasticSearchTestCase):
         call_command('elastic_purge', exclude=['InvalidIndex'], interactive=False, verbosity=0, stderr=output)
         self.assertIn("Unknown index: InvalidIndex", output.getvalue())
 
+        # Create mappings.
+        call_command('elastic_mapping', interactive=False, verbosity=0)
+
     def test_permissions(self):
         from .test_app.models import TestModel
         from .test_app.elastic_indexes import TestSearchDocument


### PR DESCRIPTION
Also add `elastic_mapping` management command so mappings can be validated manually in a predictable moment.