### PR TITLE
Rename Slurm's default partition setting

### DIFF
--- a/resolwe/flow/managers/workload_connectors/slurm.py
+++ b/resolwe/flow/managers/workload_connectors/slurm.py
@@ -41,7 +41,7 @@ class Connector(BaseConnector):
         ))
 
         # Compute target partition.
-        partition = getattr(settings, 'FLOW_SLURM_DEFAULT_PARTITION', None)
+        partition = getattr(settings, 'FLOW_SLURM_PARTITION_DEFAULT', None)
         if data.process.slug in getattr(settings, 'FLOW_SLURM_PARTITION_OVERRIDES', {}):
             partition = settings.FLOW_SLURM_PARTITION_OVERRIDES[data.process.slug]
 


### PR DESCRIPTION
Change it to `FLOW_SLURM_PARTITION_DEFAULT` so that it shares the same prefix with the `FLOW_SLURM_PARTITION_OVERRIDES` setting and becomes consistent with `FLOW_PROCESS_RESOURCE_*` settings.