### PR TITLE
Fix manager shutdown in the test runner

### DIFF
--- a/resolwe/test_helpers/test_runner.py
+++ b/resolwe/test_helpers/test_runner.py
@@ -224,10 +224,12 @@ async def _run_on_infrastructure(meth, *args, **kwargs):
                 listener = ExecutorListener(redis_params=redis_params)
                 await listener.clear_queue()
                 async with listener:
-                    with override_settings(FLOW_MANAGER_SYNC_AUTO_CALLS=True):
-                        result = await database_sync_to_async(meth)(*args, **kwargs)
-                    listener.terminate()
-                    return result
+                    try:
+                        with override_settings(FLOW_MANAGER_SYNC_AUTO_CALLS=True):
+                            result = await database_sync_to_async(meth)(*args, **kwargs)
+                        return result
+                    finally:
+                        listener.terminate()
 
 
 def _run_manager(meth, *args, **kwargs):


### PR DESCRIPTION
If an unrecoverable exception occured while running a test, and never
got caught (e.g. an unpicklable exception in a parallel test worker),
the listener would not get terminated properly, leading to a hang.