### PR TITLE
Specify loader in yaml.load() method

### DIFF
--- a/resolwe/flow/execution_engines/bash/__init__.py
+++ b/resolwe/flow/execution_engines/bash/__init__.py
@@ -34,7 +34,7 @@ class ExecutionEngine(BaseExecutionEngine):
             return []
 
         with open(path) as fn:
-            schemas = yaml.load(fn)
+            schemas = yaml.load(fn, Loader=yaml.FullLoader)
         if not schemas:
             # TODO: Logger.
             # self.stderr.write("Could not read YAML file {}".format(schema_file))

--- a/resolwe/flow/execution_engines/workflow/__init__.py
+++ b/resolwe/flow/execution_engines/workflow/__init__.py
@@ -28,7 +28,7 @@ class ExecutionEngine(BaseExecutionEngine):
             return []
 
         with open(path) as fn:
-            schemas = yaml.load(fn)
+            schemas = yaml.load(fn, Loader=yaml.FullLoader)
         if not schemas:
             # TODO: Logger.
             # self.stderr.write("Could not read YAML file {}".format(schema_file))

--- a/resolwe/flow/management/commands/register.py
+++ b/resolwe/flow/management/commands/register.py
@@ -75,7 +75,7 @@ class Command(BaseCommand):
             return []
 
         with open(schema_file) as fn:
-            schemas = yaml.load(fn)
+            schemas = yaml.load(fn, Loader=yaml.FullLoader)
         if not schemas:
             self.stderr.write("Could not read YAML file {}".format(schema_file))
             return []

--- a/resolwe/flow/utils/docs/autoprocess.py
+++ b/resolwe/flow/utils/docs/autoprocess.py
@@ -86,7 +86,7 @@ def get_processes(process_dir, base_source_uri):
     def read_yaml_file(fname):
         """Read the yaml file."""
         with open(fname) as f:
-            return yaml.load(f)
+            return yaml.load(f, Loader=yaml.FullLoader)
 
     processes = []
     for process_file in all_process_files:

--- a/resolwe/test_helpers/test_runner.py
+++ b/resolwe/test_helpers/test_runner.py
@@ -469,7 +469,7 @@ class ResolweRunner(DiscoverRunner):
             # Parse file types metadata.
             try:
                 with open(self.changes_file_types, 'r') as definition_file:
-                    types = yaml.load(definition_file)
+                    types = yaml.load(definition_file, Loader=yaml.FullLoader)
             except (OSError, ValueError):
                 raise CommandError("Failed loading or parsing file types metadata.")
         else:
@@ -522,7 +522,7 @@ class ResolweRunner(DiscoverRunner):
                     continue
 
                 with open(schema_file) as fn:
-                    schemas = yaml.load(fn)
+                    schemas = yaml.load(fn, Loader=yaml.FullLoader)
 
                 if not schemas:
                     print("WARNING: Could not read YAML file {}".format(schema_file), file=sys.stderr)
@@ -585,7 +585,7 @@ class ResolweRunner(DiscoverRunner):
         def load_process_slugs(filename):
             """Add all process slugs from specified file."""
             with open(filename, 'r') as process_file:
-                data = yaml.load(process_file)
+                data = yaml.load(process_file, Loader=yaml.FullLoader)
 
                 for process in data:
                     # Add all process slugs.


### PR DESCRIPTION
This removes YAMLLoadWarning that was caused because of
unspecified loader.