### PR TITLE
Optimize queries for retrieving permissions in elastic indices

### DIFF
--- a/resolwe/elastic/tests/test_index.py
+++ b/resolwe/elastic/tests/test_index.py
@@ -208,56 +208,56 @@ class IndexTest(ElasticSearchTestCase):
         assign_perm('view_testmodel', group, test_obj)
 
         es_objects = TestSearchDocument.search().execute()
-        self.assertEqual(es_objects[0].users_with_permissions, [user_1.pk, user_2.pk])
-        self.assertEqual(es_objects[0].groups_with_permissions, [group.pk])
+        self.assertCountEqual(es_objects[0].users_with_permissions, [user_1.pk, user_2.pk])
+        self.assertCountEqual(es_objects[0].groups_with_permissions, [group.pk])
         self.assertEqual(es_objects[0].public_permission, False)
 
         # Add user permission
         assign_perm('view_testmodel', user_3, test_obj)
 
         es_objects = TestSearchDocument.search().execute()
-        self.assertEqual(es_objects[0].users_with_permissions, [user_1.pk, user_2.pk, user_3.pk])
-        self.assertEqual(es_objects[0].groups_with_permissions, [group.pk])
+        self.assertCountEqual(es_objects[0].users_with_permissions, [user_1.pk, user_2.pk, user_3.pk])
+        self.assertCountEqual(es_objects[0].groups_with_permissions, [group.pk])
         self.assertEqual(es_objects[0].public_permission, False)
 
         # Remove user permission
         remove_perm('view_testmodel', user_2, test_obj)
 
         es_objects = TestSearchDocument.search().execute()
-        self.assertEqual(es_objects[0].users_with_permissions, [user_1.pk, user_3.pk])
-        self.assertEqual(es_objects[0].groups_with_permissions, [group.pk])
+        self.assertCountEqual(es_objects[0].users_with_permissions, [user_1.pk, user_3.pk])
+        self.assertCountEqual(es_objects[0].groups_with_permissions, [group.pk])
         self.assertEqual(es_objects[0].public_permission, False)
 
         # Remove group permission
         remove_perm('view_testmodel', group, test_obj)
 
         es_objects = TestSearchDocument.search().execute()
-        self.assertEqual(es_objects[0].users_with_permissions, [user_1.pk, user_3.pk])
-        self.assertEqual(es_objects[0].groups_with_permissions, [])
+        self.assertCountEqual(es_objects[0].users_with_permissions, [user_1.pk, user_3.pk])
+        self.assertCountEqual(es_objects[0].groups_with_permissions, [])
         self.assertEqual(es_objects[0].public_permission, False)
 
         # Add group permission
         assign_perm('view_testmodel', group, test_obj)
 
         es_objects = TestSearchDocument.search().execute()
-        self.assertEqual(es_objects[0].users_with_permissions, [user_1.pk, user_3.pk])
-        self.assertEqual(es_objects[0].groups_with_permissions, [group.pk])
+        self.assertCountEqual(es_objects[0].users_with_permissions, [user_1.pk, user_3.pk])
+        self.assertCountEqual(es_objects[0].groups_with_permissions, [group.pk])
         self.assertEqual(es_objects[0].public_permission, False)
 
         # Add public permission
         assign_perm('view_testmodel', AnonymousUser(), test_obj)
 
         es_objects = TestSearchDocument.search().execute()
-        self.assertEqual(es_objects[0].users_with_permissions, [user_pub.pk, user_1.pk, user_3.pk])
-        self.assertEqual(es_objects[0].groups_with_permissions, [group.pk])
+        self.assertCountEqual(es_objects[0].users_with_permissions, [user_pub.pk, user_1.pk, user_3.pk])
+        self.assertCountEqual(es_objects[0].groups_with_permissions, [group.pk])
         self.assertEqual(es_objects[0].public_permission, True)
 
         # Remove public permission
         remove_perm('view_testmodel', AnonymousUser(), test_obj)
 
         es_objects = TestSearchDocument.search().execute()
-        self.assertEqual(es_objects[0].users_with_permissions, [user_1.pk, user_3.pk])
-        self.assertEqual(es_objects[0].groups_with_permissions, [group.pk])
+        self.assertCountEqual(es_objects[0].users_with_permissions, [user_1.pk, user_3.pk])
+        self.assertCountEqual(es_objects[0].groups_with_permissions, [group.pk])
         self.assertEqual(es_objects[0].public_permission, False)
 
     def test_field_name(self):


### PR DESCRIPTION
This produces following queries:
```
SELECT "guardian_userobjectpermission"."user_id" FROM "guardian_userobjectpermission" WHERE ("guardian_userobjectpermission"."object_pk" = '2' AND "guardian_userobjectpermission"."permission_id" = (SELECT U0."id" FROM "auth_permission" U0 WHERE (U0."codename"::text LIKE 'view%' AND U0."content_type_id" = 16)));
```
```
SELECT "guardian_groupobjectpermission"."group_id" FROM "guardian_groupobjectpermission" WHERE ("guardian_groupobjectpermission"."object_pk" = '2' AND "guardian_groupobjectpermission"."permission_id" = (SELECT U0."id" FROM "auth_permission" U0 WHERE (U0."codename"::text LIKE 'view%' AND U0."content_type_id" = 16)));
```
```
SELECT (1) AS "a" FROM "guardian_userobjectpermission" WHERE ("guardian_userobjectpermission"."object_pk" = '2' AND "guardian_userobjectpermission"."permission_id" = (SELECT U0."id" FROM "auth_permission" U0 WHERE (U0."codename"::text LIKE 'view%' AND U0."content_type_id" = 16)) AND "guardian_userobjectpermission"."user_id" = (SELECT U0."id" FROM "auth_user" U0 WHERE U0."username" = 'public'))  LIMIT 1;
```