### PR TITLE
Add projection to DictRelatedField

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -10,10 +10,46 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 Unreleased
 ==========
 
+Changed
+-------
+- **BACKWARD INCOMPATIBLE:** Change relations between ``Data``, ``Entity`` and
+  ``Collection`` from ``ManyToMany`` to ``ManyToOne``. In practice this means
+  that ``Data.entity``, ``Data.colllecton`` and ``Entity.collection`` are now
+  ``ForeignKey``-s. This also implies the following changes:
+
+  - ``CollectionViewSet`` methods ``add_data`` and ``remove_data`` are removed
+  - ``EntityViewset`` methods ``add_data``,``remove_data``,
+    ``add_to_collection`` and ``remove_from_collection`` are removed
+  - ``EntityQuerySet`` and ``Entity`` method ``duplicate`` argument
+    ``inherit_collections`` is renamed to ``inherit_collection``.
+  - ``EntityFilter`` FilterSet field ``collections`` is renamed to
+    ``collection``.
+- **BACKWARD INCOMPATIBLE:** Change following fields in ``DataSerializer``:
+
+  - ``process_slug``, ``process_name``, ``process_type``,
+    ``process_input_schema``, ``process_output_schema`` are removed and moved
+    in ``process`` field which is now ``DictRelatedField`` that uses
+    ``ProcessSerializer`` for representation
+  - Remove ``entity_names`` and ``collection_names`` fields
+  - add ``entity`` and ``colection`` fields which are ``DictRelatedField``-s
+    that use corresponding serializers for representation
+  - Remove support for ``hydrate_entities`` and ``hydrate_collections``
+    query parameters
+- **BACKWARD INCOMPATIBLE:** Remove ``data`` field in ``EntitySerializer``
+  and ``CollectionSerializer``. This implies that parameter ``hydrate_data``
+  is no longer supported.
+- **BACKWARD INCOMPATIBLE:** Remove ``delete_content`` paremeter in ``delete``
+  method of ``EntityViewset`` and ``CollectionViewSet``. From now on, when
+  ``Entity``/``Collection`` is deleted, all it's objects are removed as well
+- Gather all ``Data`` creation logic into ``DataQuerySet.create`` method
+
 Added
 -----
 - Enable sharing based on user email
 - Support running tests with live Resolwe host on non-linux platforms
+- Add ``inherit_entity`` and ``inherit_collection`` arguments to
+  ``Data.duplicate`` and ``DataQuerySet.duplicate`` method
+- Implement ``DictRelatedField``
 
 
 ===================

--- a/resolwe/flow/serializers/collection.py
+++ b/resolwe/flow/serializers/collection.py
@@ -15,7 +15,8 @@ class CollectionSerializer(ResolweBaseSerializer):
     descriptor_schema = DictRelatedField(
         queryset=DescriptorSchema.objects.all(),
         serializer=DescriptorSchemaSerializer,
-        required=False
+        allow_null=True,
+        required=False,
     )
 
     class Meta:

--- a/resolwe/flow/serializers/data.py
+++ b/resolwe/flow/serializers/data.py
@@ -85,3 +85,11 @@ class DataSerializer(ResolweBaseSerializer):
         if not process.is_active:
             raise serializers.ValidationError("Process {} is not active.".format(process))
         return process
+
+    def validate_collection(self, collection):
+        """Verify that changing collection is done in the right place."""
+        if getattr(self.instance, 'entity', None):
+            if getattr(self.instance.entity.collection, 'id', None) != getattr(collection, 'id', None):
+                raise serializers.ValidationError("If Data is in entity, you can only move it to another collection "
+                                                  "by moving entire entity.")
+        return collection

--- a/resolwe/flow/serializers/data.py
+++ b/resolwe/flow/serializers/data.py
@@ -22,17 +22,20 @@ class DataSerializer(ResolweBaseSerializer):
     descriptor_schema = DictRelatedField(
         queryset=DescriptorSchema.objects.all(),
         serializer=DescriptorSchemaSerializer,
-        required=False
+        allow_null=True,
+        required=False,
     )
     collection = DictRelatedField(
         queryset=Collection.objects.all(),
         serializer=CollectionSerializer,
+        allow_null=True,
         required=False,
         write_permission='add',
     )
     entity = DictRelatedField(
         queryset=Entity.objects.all(),
         serializer=EntitySerializer,
+        allow_null=True,
         required=False,
         write_permission='add',
     )

--- a/resolwe/flow/serializers/entity.py
+++ b/resolwe/flow/serializers/entity.py
@@ -11,6 +11,7 @@ class EntitySerializer(CollectionSerializer):
     collection = DictRelatedField(
         queryset=Collection.objects.all(),
         serializer=CollectionSerializer,
+        allow_null=True,
         required=False,
         write_permission='add',
     )

--- a/resolwe/flow/serializers/entity.py
+++ b/resolwe/flow/serializers/entity.py
@@ -26,3 +26,11 @@ class EntitySerializer(CollectionSerializer):
             'duplicated',
             'type',
         )
+
+    def update(self, instance, validated_data):
+        """Update."""
+        source_collection = instance.collection
+        instance = super().update(instance, validated_data)
+        instance.move_to_collection(source_collection, instance.collection)
+
+        return instance

--- a/resolwe/flow/serializers/fields.py
+++ b/resolwe/flow/serializers/fields.py
@@ -72,4 +72,10 @@ class DictRelatedField(relations.RelatedField):
 
     def to_representation(self, obj):
         """Convert to representation."""
-        return self.serializer(obj, required=self.required).data
+        serializer = self.serializer(obj, required=self.required, context=self.context)
+
+        # Manually bind this serializer to field.parent as field projection
+        # relies on parent/child relations between serializers.
+        serializer.bind(self.field_name, self.parent)
+
+        return serializer.data

--- a/resolwe/rest/tests.py
+++ b/resolwe/rest/tests.py
@@ -58,8 +58,17 @@ class ProjectionTest(TestCase):
                 self.assertCountEqual(data.keys(), set(fields))
 
         # Test nested projection.
-        data = self.get_projection(['entity__name'])[0]
-        self.assertEqual(data['entity']['name'], "Test entity")
+        data = self.get_projection(['entity__name,process__contributor__username'])[0]
+        self.assertEqual(data, {
+            'entity': {
+                'name': 'Test entity'
+            },
+            'process': {
+                'contributor': {
+                    'username': 'contributor',
+                },
+            },
+        })
 
         # Test top-level JSON projection.
         data = self.get_projection(['output'])[0]
@@ -67,4 +76,10 @@ class ProjectionTest(TestCase):
 
         # Test nested projection into JSON.
         data = self.get_projection(['output__foo__bar'])[0]
-        self.assertEqual(data['output']['foo']['bar'], 42)
+        self.assertEqual(data, {
+            'output': {
+                'foo': {
+                    'bar': 42,
+                },
+            },
+        })


### PR DESCRIPTION
This fix enables the use of `fields` query parameter for DictRelatedField (Process, DescriptorSchema, collection and Entity). 