### PR TITLE
Add 'version' to minimal example

### DIFF
--- a/docs/example/example/processes/minimal.yml
+++ b/docs/example/example/processes/minimal.yml
@@ -1,4 +1,5 @@
 - slug: mini
+  version: "1.0.0"
   name: Minimalistic Process
   requirements:
     expression-engine: jinja


### PR DESCRIPTION
In really minimal example, which I always use to see if everything was set up properly is missing version string in order to avoid always modifying it once downloaded, I was wondering if we could update the documentation.