### PR TITLE
Fix tag inheritance in Data.create method

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -18,6 +18,7 @@ Fixed
 -----
 - Fix ``DictRelatedField`` so it can be used in browsable-API
 - Fix access to subfields of empty ``GroupField`` in Python processes
+- Fix tag inheritance in ``Data.create`` method
 
 
 ===================

--- a/resolwe/flow/models/data.py
+++ b/resolwe/flow/models/data.py
@@ -161,6 +161,12 @@ class DataQuerySet(models.QuerySet):
     @transaction.atomic
     def create(self, subprocess_parent=None, **kwargs):
         """Create new object with the given kwargs."""
+        entity_tags = kwargs['entity'].tags if 'entity' in kwargs else []
+        collection_tags = kwargs['collection'].tags if 'collection' in kwargs else []
+
+        # Object should have all the tags of its containers:
+        kwargs['tags'] = list(set(kwargs.get('tags', []) + entity_tags + collection_tags))
+
         obj = super().create(**kwargs)
 
         # Data dependencies

--- a/resolwe/flow/tests/test_api.py
+++ b/resolwe/flow/tests/test_api.py
@@ -46,7 +46,7 @@ class TestDataViewSetCase(TestCase):
             'get': 'children',
         })
 
-        self.collection = Collection.objects.create(contributor=self.contributor)
+        self.collection = Collection.objects.create(contributor=self.contributor, tags=['foo:bar'])
 
         self.proc = Process.objects.create(
             type='data:test:process',
@@ -208,6 +208,12 @@ class TestDataViewSetCase(TestCase):
         # Test that one Entity was created and that it was added to the same collection as Data object.
         self.assertEqual(Entity.objects.count(), 1)
         self.assertEqual(Entity.objects.first().collection.pk, self.collection.pk)
+
+        # Test that data/entity object inherits tags.
+        data = Data.objects.last()
+        self.assertEqual(data.tags, self.collection.tags)
+        entity = Entity.objects.last()
+        self.assertEqual(entity.tags, self.collection.tags)
 
     def test_collections_fields(self):
         # Create data object.

--- a/resolwe/flow/tests/test_models.py
+++ b/resolwe/flow/tests/test_models.py
@@ -288,7 +288,7 @@ class EntityModelTest(TestCase):
         self.assertTrue(entity.data.filter(pk=data.pk).exists())
 
         # Make sure tags are copied.
-        self.assertEqual(entity.tags, data.tags)
+        self.assertCountEqual(entity.tags, data.tags)
 
     def test_entity_inheritance(self):
         # Prepare Data objects with entities.


### PR DESCRIPTION
This solves the case when collection has tags, but data created inside it does not have them.