### PR TITLE
Docker cpu limit

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -18,6 +18,11 @@ Changed
   collections
 - **BACKWARD INCOMPATIBLE:** Remove ``Entity.descriptor_completed`` field
 
+Fixed
+-----
+- Fix docker executor command with ``--cpus`` limit option. This solves the
+  issue where process is killed before the timeout 30s is reached
+
 
 ===================
 19.1.0 - 2019-09-17

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,8 @@ setuptools.setup(
             'pylint~=2.3.1',
             'readme_renderer',
             'setuptools_scm',
+            # XXX: Astroid package 2.3.2 (pylint dependency) requires six==1.12
+            'six==1.12',
             'testfixtures>=4.10.0',
             'tblib>=1.3.0',
             'isort~=4.3.12',


### PR DESCRIPTION
Changes: 
- Update docker run command with --cpus option and remove --cpu-shares option.
This option is available since docker 1.13 and is set to unlimited by default. The cpus is set to the number of cores provided in process object. This limits most processes to single-threaded execution. 

- The default timeout is increased by factor 1.2. Ulimit option becomes unreliable on multithreaded processes, increase in timeout allows for some difference between realtime and measured time.