### PR TITLE
Fix readthedocs build by manually including pyasn1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,10 @@ setuptools.setup(
         'wrapt~=1.11.1',
    ],
     extras_require={
-        'docs': ['sphinx_rtd_theme'],
+        'docs': [
+            'sphinx_rtd_theme',
+            'pyasn1>=0.4.8',
+        ],
         'package': ['twine', 'wheel'],
         'test': [
             'check-manifest',


### PR DESCRIPTION
Readthedocs build fails because pyasn1 dependency is missing (dependency of service-identity). Pyasn1 package is included in setup.py because this dependency it is not installed automatically. 