### PR TITLE
Add ordering by contributor's last name to Collection and Data viewset

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -14,6 +14,7 @@ Added
 -----
 - Add support for the ``allow_custom_choice`` field property in Python
   processes
+- Add ordering by contributor's first and last name to Collection viewset
 
 Fixed
 -----

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -14,7 +14,8 @@ Added
 -----
 - Add support for the ``allow_custom_choice`` field property in Python
   processes
-- Add ordering by contributor's first and last name to Collection viewset
+- Add ordering by contributor's first and last name to Collection and Data
+  viewsets
 
 Fixed
 -----

--- a/resolwe/flow/tests/test_ordering.py
+++ b/resolwe/flow/tests/test_ordering.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from guardian.shortcuts import assign_perm
 from rest_framework.test import APITestCase
 
-from resolwe.flow.models import Process
+from resolwe.flow.models import Collection, Entity, Process
 
 
 class ProcessOrderingTest(APITestCase):
@@ -36,3 +36,65 @@ class ProcessOrderingTest(APITestCase):
         response = self.client.get(self.url, {"ordering": "-version"}, format="json")
         self.assertEqual(response.data[0]["id"], self.proc_2.id)
         self.assertEqual(response.data[1]["id"], self.proc_1.id)
+
+
+class CollectionOrderingTest(APITestCase):
+    def setUp(self):
+        super().setUp()
+
+        user_model = get_user_model()
+        self.user_1 = user_model.objects.create(username="user_1", first_name="Zion", last_name="Zucchini")
+        self.user_2 = user_model.objects.create(username="user_2", first_name="Zack", last_name="Zucchini")
+        self.user_3 = user_model.objects.create(username="user_3", first_name="Adam", last_name="Angus")
+
+        self.collection_1 = Collection.objects.create(name="Collection 1", contributor=self.user_1)
+        self.collection_2 = Collection.objects.create(name="Collection 2", contributor=self.user_2)
+        self.collection_3 = Collection.objects.create(name="Collection 3", contributor=self.user_3)
+
+        assign_perm("view_collection", AnonymousUser(), self.collection_1)
+        assign_perm("view_collection", AnonymousUser(), self.collection_2)
+        assign_perm("view_collection", AnonymousUser(), self.collection_3)
+
+        self.url = reverse("resolwe-api:collection-list")
+
+    def test_ordering(self):
+        response = self.client.get(self.url, {"ordering": "contributor__last_name,contributor__first_name"})
+        self.assertEqual(response.data[0]['contributor']['first_name'], self.user_3.first_name)
+        self.assertEqual(response.data[1]['contributor']['first_name'], self.user_2.first_name)
+        self.assertEqual(response.data[2]['contributor']['first_name'], self.user_1.first_name)
+
+        response = self.client.get(self.url, {"ordering": "-contributor__last_name,-contributor__first_name"})
+        self.assertEqual(response.data[0]['contributor']['first_name'], self.user_1.first_name)
+        self.assertEqual(response.data[1]['contributor']['first_name'], self.user_2.first_name)
+        self.assertEqual(response.data[2]['contributor']['first_name'], self.user_3.first_name)
+
+
+class EntityOrderingTest(APITestCase):
+    def setUp(self):
+        super().setUp()
+
+        user_model = get_user_model()
+        self.user_1 = user_model.objects.create(username="user_1", first_name="Zion", last_name="Zucchini")
+        self.user_2 = user_model.objects.create(username="user_2", first_name="Zack", last_name="Zucchini")
+        self.user_3 = user_model.objects.create(username="user_3", first_name="Adam", last_name="Angus")
+
+        self.entity_1 = Entity.objects.create(name="Entity 1", contributor=self.user_1)
+        self.entity_2 = Entity.objects.create(name="Entity 2", contributor=self.user_2)
+        self.entity_3 = Entity.objects.create(name="Entity 3", contributor=self.user_3)
+
+        assign_perm("view_entity", AnonymousUser(), self.entity_1)
+        assign_perm("view_entity", AnonymousUser(), self.entity_2)
+        assign_perm("view_entity", AnonymousUser(), self.entity_3)
+
+        self.url = reverse("resolwe-api:entity-list")
+
+    def test_ordering(self):
+        response = self.client.get(self.url, {"ordering": "contributor__last_name,contributor__first_name"})
+        self.assertEqual(response.data[0]['contributor']['first_name'], self.user_3.first_name)
+        self.assertEqual(response.data[1]['contributor']['first_name'], self.user_2.first_name)
+        self.assertEqual(response.data[2]['contributor']['first_name'], self.user_1.first_name)
+
+        response = self.client.get(self.url, {"ordering": "-contributor__last_name,-contributor__first_name"})
+        self.assertEqual(response.data[0]['contributor']['first_name'], self.user_1.first_name)
+        self.assertEqual(response.data[1]['contributor']['first_name'], self.user_2.first_name)
+        self.assertEqual(response.data[2]['contributor']['first_name'], self.user_3.first_name)

--- a/resolwe/flow/tests/test_ordering.py
+++ b/resolwe/flow/tests/test_ordering.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from guardian.shortcuts import assign_perm
 from rest_framework.test import APITestCase
 
-from resolwe.flow.models import Collection, Entity, Process
+from resolwe.flow.models import Collection, Data, Entity, Process
 
 
 class ProcessOrderingTest(APITestCase):
@@ -87,6 +87,38 @@ class EntityOrderingTest(APITestCase):
         assign_perm("view_entity", AnonymousUser(), self.entity_3)
 
         self.url = reverse("resolwe-api:entity-list")
+
+    def test_ordering(self):
+        response = self.client.get(self.url, {"ordering": "contributor__last_name,contributor__first_name"})
+        self.assertEqual(response.data[0]['contributor']['first_name'], self.user_3.first_name)
+        self.assertEqual(response.data[1]['contributor']['first_name'], self.user_2.first_name)
+        self.assertEqual(response.data[2]['contributor']['first_name'], self.user_1.first_name)
+
+        response = self.client.get(self.url, {"ordering": "-contributor__last_name,-contributor__first_name"})
+        self.assertEqual(response.data[0]['contributor']['first_name'], self.user_1.first_name)
+        self.assertEqual(response.data[1]['contributor']['first_name'], self.user_2.first_name)
+        self.assertEqual(response.data[2]['contributor']['first_name'], self.user_3.first_name)
+
+
+class DataOrderingTest(APITestCase):
+    def setUp(self):
+        super().setUp()
+
+        user_model = get_user_model()
+        self.user_1 = user_model.objects.create(username="user_1", first_name="Zion", last_name="Zucchini")
+        self.user_2 = user_model.objects.create(username="user_2", first_name="Zack", last_name="Zucchini")
+        self.user_3 = user_model.objects.create(username="user_3", first_name="Adam", last_name="Angus")
+
+        process = Process.objects.create(name="My process", contributor=self.user_1)
+        self.data_1 = Data.objects.create(name="Data 1", contributor=self.user_1, process=process)
+        self.data_2 = Data.objects.create(name="Data 2", contributor=self.user_2, process=process)
+        self.data_3 = Data.objects.create(name="Data 3", contributor=self.user_3, process=process)
+
+        assign_perm("view_data", AnonymousUser(), self.data_1)
+        assign_perm("view_data", AnonymousUser(), self.data_2)
+        assign_perm("view_data", AnonymousUser(), self.data_3)
+
+        self.url = reverse("resolwe-api:data-list")
 
     def test_ordering(self):
         response = self.client.get(self.url, {"ordering": "contributor__last_name,contributor__first_name"})

--- a/resolwe/flow/views/collection.py
+++ b/resolwe/flow/views/collection.py
@@ -41,6 +41,8 @@ class CollectionViewSet(
 
     ordering_fields = (
         "contributor",
+        "contributor__first_name",
+        "contributor__last_name",
         "created",
         "id",
         "modified",

--- a/resolwe/flow/views/data.py
+++ b/resolwe/flow/views/data.py
@@ -42,6 +42,8 @@ class DataViewSet(
 
     ordering_fields = (
         "contributor",
+        "contributor__first_name",
+        "contributor__last_name",
         "created",
         "finished",
         "id",


### PR DESCRIPTION
This adds an option to order collections, entities, and data objects by contributor's last name

```
/api/data?limit=3&fields=contributor&ordering=-contributor__last_name
```