### PR TITLE
Enable all top-level class definitions in Python processes

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -15,6 +15,10 @@ Added
 - Add support for the ``allow_custom_choice`` field property in Python
   processes
 
+Fixed
+-----
+- Enable all top-level class definitions in Python processes
+
 
 ===================
 21.0.0 - 2020-03-16

--- a/resolwe/process/parser.py
+++ b/resolwe/process/parser.py
@@ -1,6 +1,7 @@
 """Safe Resolwe process parser."""
 import ast
 import collections
+from inspect import isclass
 import json
 
 import asteval
@@ -173,7 +174,7 @@ class ProcessVisitor(ast.NodeVisitor):
             else:
                 continue
 
-            if issubclass(base, runtime.Process):
+            if isclass(base) and issubclass(base, runtime.Process):
                 break
         else:
             return


### PR DESCRIPTION
Currently, process registration fails if there is a top level
class definition that does not inherit from
resolwe.process.runtime. This commit fixes this limitation.

Typical case of other top-level classes are custom classes needed
in the run method.

@dblenkus I'd really like to see this fix in the April release. Is it reasonable to expect that i will?