### PR TITLE
Enable secondary Tox tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     linters,
     packaging,
     migrations
-skip_missing_interpreters = true
+skip_missing_interpreters = false
 minversion = 3.5.0
 isolated_build = true
 
@@ -22,6 +22,7 @@ basepython =
     py36: python3.6
     py37: python3.7
     py38: python3.8
+    docs,linters,packaging,migrations: python3.6
 extras =
     docs: docs
     !docs: test


### PR DESCRIPTION
Enable testing for docs, linters, packaging and migrations environments.
Disable skipping checks when interpreter is not found and prevent passing with
silent errors.