### PR TITLE
Fix errors in tests if configuration was not set

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,5 +29,6 @@ Contents
    composer
    ref
    flow
+   storage
    CHANGELOG
    contributing

--- a/docs/storage.rst
+++ b/docs/storage.rst
@@ -1,0 +1,64 @@
+=========================
+Resolwe Storage Framework
+=========================
+
+Resolwe Storage Framework is storage management system for Resolwe Flow Design.
+Currenlty it supports storing data to local filesystem, Google Cloud Storage
+and Amazon Simple Storage Service.
+
+Example settings
+================
+
+.. code::
+
+    # Storage connector sample settings.
+    LOCAL_CONNECTOR = 'local'
+    STORAGE_CONNECTORS = {
+        # Code assumes that connector named 'local' exists and points
+        # to the location FLOW_EXECUTOR["DATA_DIR"].
+        # If this is not true BAD THING WILL HAPPEN.
+        "local": {
+            "connector": "resolwe.storage.connectors.localconnector.LocalFilesystemConnector",
+            "config": {
+                "priority": 0,  # If ommited, default 100 is used
+                "path": FLOW_EXECUTOR["DATA_DIR"],
+                # Delete from here after delay days from last access to this storage
+                # location and when min_other_copies of data exist on other
+                # locations.
+                "delete": {
+                    "delay": 2,  # in days
+                    "min_other_copies": 2,
+                }
+            }
+        },
+        "S3": {
+            "connector": "resolwe.storage.connectors.s3connector.AwsS3Connector",
+            "config": {
+                "priority": 10,
+                "bucket": "genialis-test-storage",
+                "copy": {  # copy here from delay days from creation of filestorage object
+                    "delay": 5,  # in days
+                },
+                # Two values bellow affect e_tag computation on Amazon S3 connector.
+                # Default value for both settings is 8MB.
+                "multipart_threshold": 8*1024*1024,
+                "multipart_chunksize": 8*1024*1024,
+                "credentials": os.path.join(
+                    PROJECT_ROOT, "testing_credentials_s3.json"
+                ),
+            },
+        },
+        "GCS": {
+            "connector": "resolwe.storage.connectors.googleconnector.GoogleConnector",
+            "config": {
+                "priority": 10,
+                "bucket": "genialis-test-storage",
+                "credentials": os.path.join(
+                    PROJECT_ROOT, "testing_credentials_gcs.json"
+                ),
+                "copy": {
+                    "delay": 2,  # in days
+                },
+            },
+        },
+    }

--- a/resolwe/flow/managers/dispatcher.py
+++ b/resolwe/flow/managers/dispatcher.py
@@ -33,7 +33,7 @@ from resolwe.flow.engine import InvalidEngineError, load_engines
 from resolwe.flow.execution_engines import ExecutionError
 from resolwe.flow.models import Data, DataDependency, Process
 from resolwe.storage.models import FileStorage, StorageLocation
-from resolwe.storage.settings import STORAGE_CONNECTORS
+from resolwe.storage.settings import LOCAL_CONNECTOR, STORAGE_CONNECTORS
 from resolwe.test.utils import is_testing
 from resolwe.utils import BraceMessage as __
 
@@ -476,7 +476,7 @@ class Manager:
                 file_storage=file_storage,
                 url=temporary_location_string,
                 status=StorageLocation.STATUS_PREPARING,
-                connector_name=settings.LOCAL_CONNECTOR,
+                connector_name=LOCAL_CONNECTOR,
             )
             data_location.url = str(data_location.id)
             data_location.save()
@@ -541,13 +541,14 @@ class Manager:
 
         # Prepare storage connectors settings and secrets.
         connectors_settings = copy.deepcopy(STORAGE_CONNECTORS)
+        # Local connector in executor in always named 'local'.
+        connectors_settings["local"] = connectors_settings.pop(LOCAL_CONNECTOR)
         for connector_settings in connectors_settings.values():
             # Fix class name for inclusion in the executor.
             klass = connector_settings["connector"]
             klass = "executors." + klass.rsplit(".storage.")[-1]
             connector_settings["connector"] = klass
             connector_config = connector_settings["config"]
-
             # Prepare credentials for executor.
             if "credentials" in connector_config:
                 src_credentials = connector_config["credentials"]

--- a/resolwe/flow/managers/listener.py
+++ b/resolwe/flow/managers/listener.py
@@ -37,6 +37,7 @@ from resolwe.flow.models import Data, Process
 from resolwe.flow.models.utils import referenced_files
 from resolwe.flow.utils import dict_dot, iterate_fields, stats
 from resolwe.storage.models import AccessLog, ReferencedPath, StorageLocation
+from resolwe.storage.settings import LOCAL_CONNECTOR
 from resolwe.test.utils import is_testing
 from resolwe.utils import BraceMessage as __
 
@@ -507,7 +508,7 @@ class ExecutorListener:
         )
         for parent in dependencies:
             file_storage = parent.location
-            if not file_storage.has_storage_location(settings.LOCAL_CONNECTOR):
+            if not file_storage.has_storage_location(LOCAL_CONNECTOR):
                 from_location = file_storage.default_storage_location
                 if from_location is None:
                     logger.error(
@@ -520,7 +521,7 @@ class ExecutorListener:
                 to_location = StorageLocation.all_objects.get_or_create(
                     file_storage=file_storage,
                     url=from_location.url,
-                    connector_name=settings.LOCAL_CONNECTOR,
+                    connector_name=LOCAL_CONNECTOR,
                 )[0]
                 missing_data.append(
                     {

--- a/resolwe/storage/tests/storage_credentials_test_connectors.py
+++ b/resolwe/storage/tests/storage_credentials_test_connectors.py
@@ -3,9 +3,9 @@ import io
 import os
 import shutil
 import tempfile
+from unittest.mock import patch
 
 from django.conf import settings
-from django.test import override_settings
 
 from resolwe.storage.connectors import (
     AwsS3Connector,
@@ -60,7 +60,7 @@ def hashes(filename):
 
 class RegistryTest(TestCase):
     def setUp(self):
-        with override_settings(STORAGE_CONNECTORS=CONNECTORS_SETTINGS):
+        with patch("resolwe.storage.settings.STORAGE_CONNECTORS", CONNECTORS_SETTINGS):
             connectors.recreate_connectors()
 
     def tearDown(self):

--- a/resolwe/storage/tests/test_manager.py
+++ b/resolwe/storage/tests/test_manager.py
@@ -206,7 +206,6 @@ class DecisionMakerTest(TestCase):
         self.assertIsNone(self.decision_maker.delete())
 
 
-@patch("resolwe.storage.models.connectors", CONNECTORS)
 @patch("resolwe.storage.manager.connectors", CONNECTORS)
 @patch("resolwe.storage.manager.STORAGE_CONNECTORS", CONNECTORS_SETTINGS)
 class DecisionMakerOverrideRuleTest(TestCase):
@@ -313,6 +312,8 @@ class DecisionMakerOverrideRuleTest(TestCase):
             self.assertEqual(decision_maker.copy(), [])
 
 
+@patch("resolwe.storage.manager.connectors", CONNECTORS)
+@patch("resolwe.storage.manager.STORAGE_CONNECTORS", CONNECTORS_SETTINGS)
 class ManagerTest(TransactionTestCase):
     def setUp(self):
         self.file_storage1: FileStorage = FileStorage.objects.create()
@@ -390,7 +391,7 @@ class ManagerTest(TransactionTestCase):
         self.assertEqual(AccessLog.objects.all().count(), 1)
         self.assertEqual(StorageLocation.objects.all().count(), 2)
         created_location = StorageLocation.objects.exclude(pk=location_local.pk).get()
-        self.assertEqual(created_location.connector_name, "GCS")
+        self.assertEqual(created_location.connector_name, "S3")
         self.assertEqual(created_location.url, "url")
         access_log = AccessLog.objects.all().first()
         self.assertEqual(access_log.storage_location, location_local)

--- a/resolwe/test/utils.py
+++ b/resolwe/test/utils.py
@@ -19,6 +19,7 @@ from django.conf import settings
 from django.test import override_settings, tag
 
 from resolwe.storage.models import FileStorage, StorageLocation
+from resolwe.storage.settings import LOCAL_CONNECTOR
 
 __all__ = (
     "check_installed",
@@ -45,7 +46,7 @@ def create_data_location(subpath=None):
         subpath = file_storage.pk
 
     StorageLocation.objects.create(
-        url=subpath, file_storage=file_storage, connector_name=settings.LOCAL_CONNECTOR
+        url=subpath, file_storage=file_storage, connector_name=LOCAL_CONNECTOR
     )
     return file_storage
 

--- a/resolwe/test_helpers/test_runner.py
+++ b/resolwe/test_helpers/test_runner.py
@@ -32,6 +32,7 @@ from resolwe.flow.finders import get_finders
 from resolwe.flow.managers import manager, state
 from resolwe.flow.managers.listener import ExecutorListener
 from resolwe.storage.connectors import connectors
+from resolwe.storage.settings import LOCAL_CONNECTOR, STORAGE_CONNECTORS
 from resolwe.test.utils import generate_process_tag
 
 logger = logging.getLogger(__name__)
@@ -226,8 +227,8 @@ async def _run_on_infrastructure(meth, *args, **kwargs):
     with TestingContext():
         _create_test_dirs()
         with _prepare_settings():
-            storage_config = copy.deepcopy(settings.STORAGE_CONNECTORS)
-            storage_config["local"]["config"]["path"] = settings.FLOW_EXECUTOR[
+            storage_config = copy.deepcopy(STORAGE_CONNECTORS)
+            storage_config[LOCAL_CONNECTOR]["config"]["path"] = settings.FLOW_EXECUTOR[
                 "DATA_DIR"
             ]
             with patch("resolwe.storage.settings.STORAGE_CONNECTORS", storage_config):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -120,59 +120,6 @@ FLOW_EXECUTOR = {
     'REDIS_CONNECTION': REDIS_CONNECTION,
 }
 
-# Storage connector settings
-LOCAL_CONNECTOR = 'local'
-STORAGE_CONNECTORS = {
-    # Code assumes that connector named 'local' exists and points
-    # to the location FLOW_EXECUTOR["DATA_DIR"].
-    # If this is not true BAD THING WILL HAPPEN.
-    "local": {
-        "connector": "resolwe.storage.connectors.localconnector.LocalFilesystemConnector",
-        "config": {
-            "priority": 0,  # If ommited, default 100 is used
-            "path": FLOW_EXECUTOR["DATA_DIR"],
-            # Delete from here after delay days from last access to this storage
-            # location and when min_other_copies of data exist on other
-            # locations.
-            "delete": {
-                "delay": 2,  # in days
-                "min_other_copies": 2,
-            }
-        }
-    },
-    "S3": { # Can create credentials that access only part of the bucket??
-        "connector": "resolwe.storage.connectors.s3connector.AwsS3Connector",
-        "config": {
-            "priority": 10,
-            "bucket": "genialis-test-storage",
-            "copy": {  # copy here from delay days from creation of filestorage object
-                "delay": 5,  # in days
-            },
-            # Two values bellow affect e_tag computation on Amazon S3 connector.
-            # Default value for both settings is 8MB.
-            "multipart_threshold": 8*1024*1024,
-            "multipart_chunksize": 8*1024*1024,
-            "credentials": os.path.join(
-                PROJECT_ROOT, "testing_credentials_s3.json"
-            ),
-        },
-    },
-    "GCS": {
-        "connector": "resolwe.storage.connectors.googleconnector.GoogleConnector",
-        "config": {
-            "priority": 10,
-            "bucket": "genialis-test-storage",
-            "credentials": os.path.join(
-                PROJECT_ROOT, "testing_credentials_gcs.json"
-            ),
-            "copy": {
-                "delay": 2,  # in days
-            },
-        },
-    },
-}
-
-
 # Check if any Manager settings are set via environment variables
 manager_prefix = os.environ.get('RESOLWE_MANAGER_REDIS_PREFIX', 'resolwe.flow.manager')
 FLOW_MANAGER = {


### PR DESCRIPTION
When STORAGE_LOCATION or LOCAL_CONNECTOR were not set in settings some
tests have failed. To make sure tests pass without these configuration
entries they were removed from the setting file.