### PR TITLE
Add isnull related lookup filter

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -27,6 +27,7 @@ Added
 - Add management command to start storage manager
 - Add tests for new storage framework
 - Add cleanup manager for removing unreferenced data
+- Add ``isnull`` related lookup filter
 
 
 ===================

--- a/resolwe/flow/filters.py
+++ b/resolwe/flow/filters.py
@@ -24,6 +24,7 @@ from .models import Collection, Data, DescriptorSchema, Entity, Process, Relatio
 RELATED_LOOKUPS = [
     "exact",
     "in",
+    "isnull",
 ]
 NUMBER_LOOKUPS = [
     "exact",

--- a/resolwe/flow/tests/test_filtering.py
+++ b/resolwe/flow/tests/test_filtering.py
@@ -509,6 +509,9 @@ class EntityViewSetFiltersTest(BaseViewSetFiltersTest):
             {"collection__in": "{},{}".format(self.collection1.pk, "999999")},
             self.entities[:1],
         )
+        self._check_filter(
+            {"collection__isnull": True}, self.entities[2:],
+        )
 
     def test_filter_collection_name(self):
         self._check_filter({"collection__name": "My collection"}, [self.entities[0]])
@@ -830,6 +833,9 @@ class DataViewSetFiltersTest(BaseViewSetFiltersTest):
             {"collection__in": "{},{}".format(self.collection1.pk, "999999")},
             self.data[:1],
         )
+        self._check_filter(
+            {"collection__isnull": True}, self.data[2:],
+        )
 
     def test_filter_collection_name(self):
         self._check_filter({"collection__name": "My collection"}, [self.data[0]])
@@ -854,6 +860,9 @@ class DataViewSetFiltersTest(BaseViewSetFiltersTest):
         self._check_filter(
             {"entity__in": "{},{}".format(self.entity1.pk, self.entity2.pk, "999999")},
             self.data[:2],
+        )
+        self._check_filter(
+            {"entity__isnull": True}, self.data[2:],
         )
 
     def test_filter_entity_name(self):


### PR DESCRIPTION
With this filter, you can for example find orphaned data objects:
```
data?collection__isnull=true&entity__isnull=true
```