### PR TITLE
Add entity_always_create in Process serializer

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -30,6 +30,10 @@ Added
 - Add ``isnull`` related lookup filter
 - Add ``entity_count`` to the ``Collection`` serializer
 
+Fixed
+-----
+- Add entity_always_create in ``Process`` serializer
+
 
 ===================
 21.1.0 - 2020-04-14

--- a/resolwe/flow/serializers/process.py
+++ b/resolwe/flow/serializers/process.py
@@ -22,6 +22,7 @@ class ProcessSerializer(ResolweBaseSerializer):
             "contributor",
             "data_name",
             "description",
+            "entity_always_create",
             "entity_descriptor_schema",
             "entity_input",
             "entity_type",


### PR DESCRIPTION
This should be done long ago, but we realized only now that it is missing.