### PR TITLE
When deleting consider only finished locations & add new exception to transfer_exceptions

### DIFF
--- a/resolwe/storage/connectors/transfer.py
+++ b/resolwe/storage/connectors/transfer.py
@@ -21,8 +21,9 @@ if TYPE_CHECKING:
 
 try:
     from google.api_core.exceptions import ServiceUnavailable
+    from google.resumable_media.common import DataCorruption
 
-    gcs_exceptions = [ServiceUnavailable]
+    gcs_exceptions = [DataCorruption, ServiceUnavailable]
 except ModuleNotFoundError:
     gcs_exceptions = []
 

--- a/resolwe/storage/manager.py
+++ b/resolwe/storage/manager.py
@@ -143,7 +143,9 @@ class DecisionMaker:
 
         # Never remove the last storage location.
         min_other_copies = rules.get("min_other_copies", 1)
-        current_copies = self.file_storage.storage_locations.count()
+        current_copies = self.file_storage.storage_locations.filter(
+            status=StorageLocation.STATUS_DONE
+        ).count()
         rule_results["has_copies"] = min_other_copies < current_copies
 
         # Never remove the location with "highest" priority that is

--- a/resolwe/storage/tests/test_manager.py
+++ b/resolwe/storage/tests/test_manager.py
@@ -224,12 +224,15 @@ class DecisionMakerTest(TestCase):
             last_update=timezone.now() - timedelta(days=5)
         )
         self.assertIsNone(self.decision_maker.delete())
-        StorageLocation.objects.create(
+        storage_location = StorageLocation.objects.create(
             file_storage=self.file_storage,
             url="url",
             connector_name="GCS1",
-            status=StorageLocation.STATUS_DONE,
+            status=StorageLocation.STATUS_DELETING,
         )
+        self.assertIsNone(self.decision_maker.delete())
+        storage_location.status = StorageLocation.STATUS_DONE
+        storage_location.save()
         self.assertEqual(self.decision_maker.delete(), location_gcs)
 
     def test_delete_priority(self):


### PR DESCRIPTION
in corner caes there may exist locations with status set to PREPARING,
UPLOADING or DELETING. These locations must not be counted as active.

Luckily, the bug can not cause data loss even in border-line cases since default location is never deleted.