### PR TITLE
Improve process termination

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -6,6 +6,15 @@ All notable changes to this project are documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 
+==========
+Unreleased
+==========
+
+Fixed
+-----
+- Make sure to terminate Docker container before executor exits
+
+
 ===================
 23.0.0 - 2020-08-17
 ===================

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -10,6 +10,11 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 Unreleased
 ==========
 
+Changed
+-------
+- **BACKWARD INCOMPATIBLE:** Terminate Python process immediately after
+  ``self.error`` method is called inside the process
+
 Fixed
 -----
 - Make sure to terminate Docker container before executor exits

--- a/resolwe/flow/executors/run.py
+++ b/resolwe/flow/executors/run.py
@@ -248,13 +248,8 @@ class BaseFlowExecutor:
                         if process_rc > 0:
                             log_file.close()
                             json_file.close()
-                            await self._send_manager_command(
-                                ExecutorProtocol.FINISH,
-                                extra_fields={
-                                    ExecutorProtocol.FINISH_PROCESS_RC: process_rc
-                                },
-                            )
-                            return
+
+                            return {ExecutorProtocol.FINISH_PROCESS_RC: process_rc}
 
                         # Debug output
                         # Not referenced in Data object

--- a/resolwe/process/runtime.py
+++ b/resolwe/process/runtime.py
@@ -231,6 +231,7 @@ class Process(metaclass=ProcessMeta):
         report = resolwe_runtime_utils.error(" ".join([str(x) for x in args]))
         # TODO: Use the protocol to report progress.
         print(report)
+        sys.exit(1)
 
     def get_data_id_by_slug(self, slug):
         """Find data object ID for given slug.


### PR DESCRIPTION
Improvments include:
* wait for (and kill) the process only if it was not yet terminated
* don't wait for process in Docker executor as it is already handled in
  the parent function
* don't log error when process is already terminated
* log error if Docker container removal fails