### PR TITLE
Fix non-required ListField in Python processes

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -14,6 +14,9 @@ Added
 -----
 - Support accessing Data name in Python processes through ``self.name``
 
+Fixed
+-----
+- Fix an issue with non-required ``ListField``-s in Python processes
 
 ===================
 24.0.0 - 2020-09-14

--- a/resolwe/process/runtime.py
+++ b/resolwe/process/runtime.py
@@ -8,7 +8,7 @@ import urllib
 import resolwe_runtime_utils
 
 from .descriptor import ProcessDescriptor
-from .fields import Field, RelationDescriptor
+from .fields import Field, ListField, RelationDescriptor
 
 try:
     from plumbum import local as Cmd
@@ -66,7 +66,11 @@ class _IoBase:
         return self._data.items()
 
     def __getattr__(self, name):
-        return self._data.get(name, None)
+        fallback = None
+        if isinstance(self._fields.get(name), ListField):
+            fallback = list()
+
+        return self._data.get(name, fallback)
 
     def __setattr__(self, name, value):
         if self.frozen:

--- a/resolwe/process/tests/processes/python_test.py
+++ b/resolwe/process/tests/processes/python_test.py
@@ -388,3 +388,24 @@ class DataNameProcess(Process):
 
     def run(self, inputs, outputs):
         outputs.name = self.name
+
+
+class ListFieldProcess(Process):
+    slug = "list-field-non-required"
+    name = "Test non-required ListField"
+    version = "0.0.1"
+    process_type = "data:python"
+
+    class Input:
+        list_str = ListField(
+            StringField(), label="Non-required string ListField.", required=False
+        )
+        list_data = ListField(
+            DataField(""), label="Non-required data ListField.", required=False
+        )
+
+    def run(self, inputs, outputs):
+        for _ in inputs.list_str:
+            pass
+        for _ in inputs.list_data:
+            pass

--- a/resolwe/process/tests/test_python_process.py
+++ b/resolwe/process/tests/test_python_process.py
@@ -326,6 +326,12 @@ class PythonProcessTest(ProcessTestCase):
         data = self.run_process("data-name-process", {"data_input": data_input.id})
         self.assertEqual(data.output["name"], "Data with entity")
 
+    @with_docker_executor
+    @tag_process("list-field-non-required")
+    def test_list_field(self):
+        """Test non-required ListField."""
+        self.run_process("list-field-non-required")
+
 
 class PythonProcessRequirementsTest(ProcessTestCase):
     def setUp(self):


### PR DESCRIPTION
Until now, non-required ListField would fail if default=[] was
not provided.