### PR TITLE
Build tagged version of communication container

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,10 +2,14 @@ name: Build Docker Images
 
 on:
   push:
-    branches: master
-  tags:
-    - "[0-9]+.[0-9]+.[0-9]+*"
-  
+    branches:
+      - master
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+*"
+
+env:
+  AWS_REGISTRY: public.ecr.aws/genialis
+  AWS_REGION: us-east-1
 
 jobs:
   build:
@@ -18,15 +22,24 @@ jobs:
           - image: fedora-33
             context: resolwe/toolkit/docker_images/base/
             file: resolwe/toolkit/docker_images/base/Dockerfile.fedora-33
-            tags: resolwe/base:fedora-33dev
+            repository: resolwe/base
+            devel-tag: fedora-33dev
+            stable-tag: fedora-33
+            stable-suffix: "f"
           - image: ubuntu-20.04
             context: resolwe/toolkit/docker_images/base/
             file: resolwe/toolkit/docker_images/base/Dockerfile.ubuntu-20.04
-            tags: resolwe/base:ubuntu-20.04dev
+            repository: resolwe/base
+            devel-tag: ubuntu-20.04dev
+            stable-tag: ubuntu-20.04
+            stable-suffix: ""
           - image: communication
             context: resolwe/
             file: resolwe/flow/docker_images/Dockerfile.communication
-            tags: resolwe/com:latest
+            repository: resolwe/com
+            devel-tag: latest
+            stable-tag: stable
+            stable-suffix: ""
 
     steps:
       - uses: actions/checkout@v2
@@ -34,41 +47,37 @@ jobs:
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
+
+      - name: Login to Public ECR
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push ${{ matrix.image }} image
+          registry: public.ecr.aws
+          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Build and push image ${{ matrix.image }}
+        if: "github.ref == 'refs/heads/master'"
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}
-          tags: ${{ matrix.tags }}
+          tags: |
+            ${{ env.AWS_REGISTRY }}/${{ matrix.repository }}:${{ matrix.devel-tag }}
+            ${{ env.AWS_REGISTRY }}/${{ matrix.repository }}:latest
           push: true
 
-
-  tagged:
-    runs-on: ubuntu-20.04
-    if: "startsWith(github.ref, 'refs/tags')"
-    steps:
       - name: Get the docker image tag
+        if: "startsWith(github.ref, 'refs/tags')"
         id: get_tag
         run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
-      - uses: actions/checkout@v2
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push ${{ matrix.image }} image
+
+      - name: Build and push tagged image ${{ matrix.image }}
+        if: "startsWith(github.ref, 'refs/tags')"
         uses: docker/build-push-action@v2
         with:
-          context: resolwe/
-          file: resolwe/flow/docker_images/Dockerfile.communication
-          tags: resolwe/com:${{ steps.get_tag.outputs.VERSION }}
+          context: ${{ matrix.context }}
+          file: ${{ matrix.file }}
+          tags: |
+            ${{ env.AWS_REGISTRY }}/${{ matrix.repository }}:${{ steps.get_tag.outputs.VERSION }}${{ matrix.stable-suffix }}
+            ${{ env.AWS_REGISTRY }}/${{ matrix.repository }}:${{ matrix.stable-tag }}
           push: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,9 @@ name: Build Docker Images
 on:
   push:
     branches: master
+  tags:
+    - "[0-9]+.[0-9]+.[0-9]+*"
+  
 
 jobs:
   build:
@@ -15,11 +18,11 @@ jobs:
           - image: fedora-33
             context: resolwe/toolkit/docker_images/base/
             file: resolwe/toolkit/docker_images/base/Dockerfile.fedora-33
-            tags: resolwe/base:fedora-33
+            tags: resolwe/base:fedora-33dev
           - image: ubuntu-20.04
             context: resolwe/toolkit/docker_images/base/
             file: resolwe/toolkit/docker_images/base/Dockerfile.ubuntu-20.04
-            tags: resolwe/base:ubuntu-20.04
+            tags: resolwe/base:ubuntu-20.04dev
           - image: communication
             context: resolwe/
             file: resolwe/flow/docker_images/Dockerfile.communication
@@ -42,4 +45,30 @@ jobs:
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}
           tags: ${{ matrix.tags }}
+          push: true
+
+
+  tagged:
+    runs-on: ubuntu-20.04
+    if: "startsWith(github.ref, 'refs/tags')"
+    steps:
+      - name: Get the docker image tag
+        id: get_tag
+        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+      - uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push ${{ matrix.image }} image
+        uses: docker/build-push-action@v2
+        with:
+          context: resolwe/
+          file: resolwe/flow/docker_images/Dockerfile.communication
+          tags: resolwe/com:${{ steps.get_tag.outputs.VERSION }}
           push: true


### PR DESCRIPTION
when commit is tagged. The tag itself is used as a docker image tag.
If the commit is not tagged build the development version of the image.

Additional commit:
- Fix errors and code cleanup
- Explicit separation of development and stable tags
- Push to ECR instead of Docker hub