### PR TITLE
Fix show standard button in GUI

### DIFF
--- a/resolwe/storage/connectors/s3connector.py
+++ b/resolwe/storage/connectors/s3connector.py
@@ -49,6 +49,10 @@ class AwsS3Connector(BaseStorageConnector):
             region_name=self.config.get("region_name"),
         )
         self.awss3 = self.session.resource("s3")
+
+        self.client = self.session.client(
+            "s3", config=botocore.client.Config(signature_version="s3v4")
+        )
         self.client = self.session.client("s3")
         self.sts = self.session.client("sts")
 


### PR DESCRIPTION
When data was stored on S3 and presigned URL generated signature
version 2, then stardard output could not be fetched (with(signature
could not be matched error).

The solution was to force using signatures of version 4 in S3 connector.