### PR TITLE
Transfer inputs in init container faster

### DIFF
--- a/resolwe/flow/executors/init_container.py
+++ b/resolwe/flow/executors/init_container.py
@@ -13,7 +13,6 @@ import sys
 from collections import defaultdict
 from contextlib import suppress
 from distutils.util import strtobool
-from functools import partial
 from pathlib import Path
 
 import zmq
@@ -118,7 +117,7 @@ async def download_to_location(
     # be re-raised.
     for future in paralelize(
         objects=files,
-        worker=partial(transfer.transfer_chunk, None),
+        worker=lambda objects: transfer.transfer_chunk(None, objects),
         max_threads=max_threads,
     ):
         future.result()

--- a/resolwe/storage/connectors/baseconnector.py
+++ b/resolwe/storage/connectors/baseconnector.py
@@ -61,6 +61,10 @@ class BaseStorageConnector(metaclass=abc.ABCMeta):
         self.config = copy.deepcopy(config)
         self.name = name
         self.supported_hash = []
+        # Does connector preserves data integrity during download.
+        self.get_ensures_data_integrity = False
+        # Does connector preserves data integrity during upload.
+        self.put_ensures_data_integrity = False
 
     @abc.abstractproperty
     def base_path(self) -> PurePath:

--- a/resolwe/storage/connectors/localconnector.py
+++ b/resolwe/storage/connectors/localconnector.py
@@ -19,6 +19,8 @@ class LocalFilesystemConnector(BaseStorageConnector):
         self.path = config["path"]
         self.supported_hash = ["crc32c", "md5", "awss3etag"]
         self.multipart_chunksize = self.CHUNK_SIZE
+        self.get_ensures_data_integrity = True
+        self.put_ensures_data_integrity = True
 
     @validate_urls
     @validate_url

--- a/resolwe/storage/connectors/s3connector.py
+++ b/resolwe/storage/connectors/s3connector.py
@@ -32,6 +32,9 @@ class AwsS3Connector(BaseStorageConnector):
         )
         self.use_threads = True
 
+        # Ensured by TLS protocol used for transport.
+        self.get_ensures_data_integrity = True
+
         self._session = None
         self._client = None
         self._sts = None


### PR DESCRIPTION
by skipping the hash computation.