### PR TITLE
Prefer new zmq connections with the same identity

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -6,6 +6,16 @@ All notable changes to this project are documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 
+==========
+Unreleased
+==========
+
+Fixed
+-----
+- Fix connection timeout in communication container when sending initial
+  message to the listener
+
+
 ===================
 27.1.0 - 2021-03-15
 ===================

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -6,9 +6,9 @@ All notable changes to this project are documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 
-==========
-Unreleased
-==========
+===================
+27.1.1 - 2021-03-21
+===================
 
 Fixed
 -----

--- a/resolwe/flow/managers/listener/listener.py
+++ b/resolwe/flow/managers/listener/listener.py
@@ -450,6 +450,7 @@ class ListenerProtocol(BaseProtocol):
         if zmq_socket is None:
             zmq_context: zmq.asyncio.Context = zmq.asyncio.Context.instance()
             zmq_socket = zmq_context.socket(zmq.ROUTER)
+            zmq_socket.setsockopt(zmq.ROUTER_HANDOVER, 1)
             for host in hosts:
                 zmq_socket.bind(f"{protocol}://{host}:{port}")
 

--- a/resolwe/test_helpers/test_runner.py
+++ b/resolwe/test_helpers/test_runner.py
@@ -168,6 +168,7 @@ def _prepare_settings():
 
     zmq_context: zmq.asyncio.Context = zmq.asyncio.Context.instance()
     zmq_socket: zmq.asyncio.Socket = zmq_context.socket(zmq.ROUTER)
+    zmq_socket.setsockopt(zmq.ROUTER_HANDOVER, 1)
 
     host = hosts[0]
     port = zmq_socket.bind_to_random_port(


### PR DESCRIPTION
Listener uses zmq router socket for connection handling. When second
client connects with already existing identity, its connection is
rejected and responses are sent to the already connected client.

When zmq.ROUTER_HANDOVER is set to 1 the connection to the already
connected  client is closed and the new one is used.