### PR TITLE
Allow to change Entity descriptor in Python process

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -31,6 +31,7 @@ Fixed
 Changed
 -------
 - Use tagged base image in ``upload-file`` process
+- Allow to change Entity descriptor in Python process.
 
 
 ===================

--- a/resolwe/flow/managers/listener/python_process_plugin.py
+++ b/resolwe/flow/managers/listener/python_process_plugin.py
@@ -303,6 +303,7 @@ class ExposeEntity(ExposeObjectPlugin):
             "description",
             "tags",
             "name",
+            "descriptor",
         }
         not_allowed_keys = set(model_data.keys()) - allowed_fields
         if not_allowed_keys:

--- a/resolwe/process/tests/processes/python_test.py
+++ b/resolwe/process/tests/processes/python_test.py
@@ -507,6 +507,23 @@ class ChangeEntityName(Process):
         entity.name = inputs.entity_name
 
 
+class ChangeEntityDescriptor(Process):
+    slug = "change-entity-descriptor"
+    name = "Change entity descriptor"
+    data_name = "{{ data_input | name | default('?') }}"
+    version = "1.0.0"
+    process_type = "data:name"
+    requirements = {"expression-engine": "jinja"}
+
+    class Input:
+        entity_id = IntegerField(label="Entity id")
+        description = StringField(label="New description")
+
+    def run(self, inputs, outputs):
+        entity = Entity.get(pk=inputs.entity_id)
+        entity.descriptor = {"Description": inputs.description}
+
+
 class TestStorage(Process):
     slug = "storage-objects-test"
     name = "Test working with storage objects"


### PR DESCRIPTION
This adds the ability to change descriptor from within the python process.