### PR TITLE
Do not raise exception when exiting runlistener

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -6,6 +6,15 @@ All notable changes to this project are documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 
+==========
+Unreleased
+==========
+
+Fixed
+-----
+- Do not raise exception when terminating ``runlistener`` management command
+
+ 
 ===================
 28.0.3 - 2021-05-04
 ===================

--- a/resolwe/flow/management/commands/runlistener.py
+++ b/resolwe/flow/management/commands/runlistener.py
@@ -47,7 +47,7 @@ class Command(BaseCommand):
             loop.add_signal_handler(SIGINT, lambda: asyncio.ensure_future(_killer()))
             loop.add_signal_handler(SIGTERM, lambda: asyncio.ensure_future(_killer()))
             async with listener:
-                await listener.run()
+                await listener.should_stop.wait()
 
         loop = asyncio.new_event_loop()
         loop.run_until_complete(_runner())


### PR DESCRIPTION
Wait for the future started inside context manager instead of creating
the new one, which causes AssertionError to be thrown on script exit.