### PR TITLE
Make gp2 default EBS storage class

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -6,9 +6,9 @@ All notable changes to this project are documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 
-==========
-Unreleased
-==========
+===================
+28.0.3 - 2021-05-04
+===================
 
 Changed
 -------

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -6,6 +6,15 @@ All notable changes to this project are documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 
+==========
+Unreleased
+==========
+
+Changed
+-------
+- Make ``gp2`` default EBS storage class
+
+
 ===================
 28.0.2 - 2021-05-03
 ===================

--- a/resolwe/flow/managers/workload_connectors/kubernetes.py
+++ b/resolwe/flow/managers/workload_connectors/kubernetes.py
@@ -449,7 +449,7 @@ class Connector(BaseConnector):
             "metadata": {"name": claim_name},
             "spec": {
                 "accessModes": ["ReadWriteOnce"],
-                "storageClassName": volume_config.get("storageClassName", "gp3"),
+                "storageClassName": volume_config.get("storageClassName", "gp2"),
                 "resources": {
                     "requests": {
                         "storage": size,


### PR DESCRIPTION
New gp3 storage class has problems and sometimes halts the entire pod.
Until this issue is resolved the old and tested gp2 class will be the
default.