### PR TITLE
Transform docker image names with mapper

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -19,6 +19,11 @@ Changed
 - Make S3 connectors use system credentials when they are not explicitely
   given in settings
 
+Added
+-----
+- Make it possible to rewrite container image names in kubernetes workload
+  connector
+
 
 ===================
 28.0.4 - 2021-05-04


### PR DESCRIPTION
When docker image name starts with the key in the mapper the matching
part is replaced with the corresponding value.