### PR TITLE
Set hashes during upload

### DIFF
--- a/resolwe/storage/connectors/baseconnector.py
+++ b/resolwe/storage/connectors/baseconnector.py
@@ -156,13 +156,18 @@ class BaseStorageConnector(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def push(
-        self, stream: BinaryIO, url: Union[str, PathLike], chunk_size: int = CHUNK_SIZE
+        self,
+        stream: BinaryIO,
+        url: Union[str, PathLike],
+        chunk_size: int = CHUNK_SIZE,
+        hashes: Dict[str, str] = {},
     ):
         """Push data from the stream to the given URL.
 
         :param stream: given stream.
         :param url: where the data in the stream will be stored.
         :param chunk_size: the chunk_size to use.
+        :param hashes: the hashes to set (as metadata) on the uploaded object.
         """
         raise NotImplementedError
 

--- a/resolwe/storage/connectors/googleconnector.py
+++ b/resolwe/storage/connectors/googleconnector.py
@@ -65,12 +65,14 @@ class GoogleConnector(BaseStorageConnector):
                         blob.delete()
 
     @validate_url
-    def push(self, stream, url, chunk_size=BaseStorageConnector.CHUNK_SIZE):
+    def push(self, stream, url, chunk_size=BaseStorageConnector.CHUNK_SIZE, hashes={}):
         """Push data from the stream to the given URL."""
         url = os.fspath(url)
         mime_type = mimetypes.guess_type(url)[0]
         blob = self.bucket.blob(url)
         blob.upload_from_file(stream, content_type=mime_type)
+        if hashes:
+            self.set_hashes(url, hashes)
 
     @validate_url
     def get(self, url, stream, chunk_size=BaseStorageConnector.CHUNK_SIZE):

--- a/resolwe/storage/connectors/localconnector.py
+++ b/resolwe/storage/connectors/localconnector.py
@@ -48,8 +48,11 @@ class LocalFilesystemConnector(BaseStorageConnector):
                 shutil.rmtree(os.fspath(self.base_path / url))
 
     @validate_url
-    def push(self, stream, url, chunk_size=BaseStorageConnector.CHUNK_SIZE):
-        """Push data from the stream to the given URL."""
+    def push(self, stream, url, chunk_size=BaseStorageConnector.CHUNK_SIZE, hashes={}):
+        """Push data from the stream to the given URL.
+
+        The chunk_size and hashes arguments are ignored.
+        """
         data_remaining = True
         path = self.base_path / url
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/resolwe/storage/connectors/s3connector.py
+++ b/resolwe/storage/connectors/s3connector.py
@@ -75,12 +75,13 @@ class AwsS3Connector(BaseStorageConnector):
         return getattr(self, name)
 
     @validate_url
-    def push(self, stream, url, chunk_size=BaseStorageConnector.CHUNK_SIZE):
+    def push(self, stream, url, chunk_size=BaseStorageConnector.CHUNK_SIZE, hashes={}):
         """Push data from the stream to the given URL."""
         url = os.fspath(url)
         mime_type = mimetypes.guess_type(url)[0]
         extra_args = {} if mime_type is None else {"ContentType": mime_type}
         extra_args["Metadata"] = {"_upload_chunk_size": str(chunk_size)}
+        extra_args["Metadata"].update(hashes)
         self.client.upload_fileobj(
             stream,
             self.bucket_name,

--- a/resolwe/storage/connectors/transfer.py
+++ b/resolwe/storage/connectors/transfer.py
@@ -267,7 +267,9 @@ class Transfer:
         #   from from_connector to to_connector.
         if from_connector.can_open_stream:
             stream = from_connector.open_stream(from_url, "rb")
-            to_connector.push(stream, to_base_url / to_url, chunk_size=chunk_size)
+            to_connector.push(
+                stream, to_base_url / to_url, chunk_size=chunk_size, hashes=hashes
+            )
             stream.close()
 
         elif to_connector.can_open_stream:
@@ -300,6 +302,7 @@ class Transfer:
                     data_stream,
                     to_base_url / to_url,
                     chunk_size=chunk_size,
+                    hashes=hashes,
                 )
                 download_task.add_done_callback(partial(future_done, data_stream))
                 futures = (download_task, upload_task)


### PR DESCRIPTION
to avoid creating multiple versions of the object in S3 bucket when
versioning is enabled.