### PR TITLE
Separate build and push workflow for stable and staging tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,8 @@ env:
 
 jobs:
   build:
+    env:
+      TAGS:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
@@ -23,23 +25,17 @@ jobs:
             context: resolwe/toolkit/docker_images/base/
             file: resolwe/toolkit/docker_images/base/Dockerfile.fedora-33
             repository: resolwe/base
-            devel-tag: fedora-33dev
-            stable-tag: fedora-33
-            stable-suffix: "f"
+            suffix: -fedora
           - image: ubuntu-20.04
             context: resolwe/toolkit/docker_images/base/
             file: resolwe/toolkit/docker_images/base/Dockerfile.ubuntu-20.04
             repository: resolwe/base
-            devel-tag: ubuntu-20.04dev
-            stable-tag: ubuntu-20.04
-            stable-suffix: ""
+            suffix: ""
           - image: communication
             context: resolwe/
             file: resolwe/flow/docker_images/Dockerfile.communication
             repository: resolwe/com
-            devel-tag: latest
-            stable-tag: stable
-            stable-suffix: ""
+            suffix: ""
 
     steps:
       - uses: actions/checkout@v2
@@ -55,29 +51,35 @@ jobs:
           username: ${{ secrets.AWS_ACCESS_KEY_ID }}
           password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-      - name: Build and push image ${{ matrix.image }}
-        if: "github.ref == 'refs/heads/master'"
-        uses: docker/build-push-action@v2
-        with:
-          context: ${{ matrix.context }}
-          file: ${{ matrix.file }}
-          tags: |
-            ${{ env.AWS_REGISTRY }}/${{ matrix.repository }}:${{ matrix.devel-tag }}
-            ${{ env.AWS_REGISTRY }}/${{ matrix.repository }}:latest
-          push: true
+      - name: Generate tags
+        run: |
+          tags=""
 
-      - name: Get the docker image tag
-        if: "startsWith(github.ref, 'refs/tags')"
-        id: get_tag
-        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+          # Devel (all commits to master)
+          if [[ ${{ github.ref == 'refs/heads/master' }} ]];
+          then
+            tags=$tags,${{ env.AWS_REGISTRY }}/${{ matrix.repository }}:latest${{ matrix.suffix }}
+          fi
+
+          # Staging (all tagged commits)
+          if [[ ${{ startsWith(github.ref, 'refs/tags') }} ]];
+          then
+            tags=$tags,${{ env.AWS_REGISTRY }}/${{ matrix.repository }}:${GITHUB_REF#refs/tags/}${{ matrix.suffix }}
+            tags=$tags,${{ env.AWS_REGISTRY }}/${{ matrix.repository }}:staging${{ matrix.suffix }}
+          fi
+
+          # Stable (all commits tagged with a stable version tag)
+          if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]];
+          then
+            tags=$tags,${{ env.AWS_REGISTRY }}/${{ matrix.repository }}:stable${{ matrix.suffix }}
+          fi
+
+          echo "TAGS=$tags" >> $GITHUB_ENV
 
       - name: Build and push tagged image ${{ matrix.image }}
-        if: "startsWith(github.ref, 'refs/tags')"
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}
-          tags: |
-            ${{ env.AWS_REGISTRY }}/${{ matrix.repository }}:${{ steps.get_tag.outputs.VERSION }}${{ matrix.stable-suffix }}
-            ${{ env.AWS_REGISTRY }}/${{ matrix.repository }}:${{ matrix.stable-tag }}
+          tags: ${{ env.TAGS }}
           push: true


### PR DESCRIPTION
- Build configuration for stable containers now only includes release tags, not pre-release tags (a* versions).
- Additional build configuration for staging matches all tags.