### PR TITLE
Remove reference to runtime dir in dispatcher

### DIFF
--- a/resolwe/flow/managers/dispatcher.py
+++ b/resolwe/flow/managers/dispatcher.py
@@ -250,8 +250,7 @@ class Manager:
         host, port, protocol = self._get_listener_settings(data, workload_class)
         argv[-1] += " {} {} {}".format(host, port, protocol)
 
-        runtime_dir = storage_settings.FLOW_VOLUMES["runtime"]["config"]["path"]
-        return self.connectors[class_name].submit(data, os.fspath(runtime_dir), argv)
+        return self.connectors[class_name].submit(data, argv)
 
     def _get_data_connector_name(self) -> str:
         """Return storage connector that will be used for new data object.

--- a/resolwe/flow/managers/workload_connectors/base.py
+++ b/resolwe/flow/managers/workload_connectors/base.py
@@ -7,6 +7,9 @@ Base Class
 """
 
 
+from resolwe.flow.models import Data
+
+
 class BaseConnector:
     """The abstract base class for workload manager connectors.
 
@@ -18,19 +21,18 @@ class BaseConnector:
     all done by the manager.
     """
 
-    def submit(self, data, runtime_dir, argv):
+    def submit(self, data: Data, argv):
         """Submit the job to the workload management system.
 
         :param data: The :class:`~resolwe.flow.models.Data` object that
             is to be run.
-        :param runtime_dir: The directory the executor is run from.
         :param argv: The argument vector used to spawn the executor.
         """
         raise NotImplementedError(
             "Subclasses of BaseConnector must implement a submit() method."
         )
 
-    def cleanup(self, data_id):
+    def cleanup(self, data_id: int):
         """Perform final cleanup after data object is finished processing."""
         raise NotImplementedError(
             "Subclasses of BaseConnector must implement a cleanup() method."

--- a/resolwe/flow/managers/workload_connectors/celery.py
+++ b/resolwe/flow/managers/workload_connectors/celery.py
@@ -10,8 +10,9 @@ import sys
 
 from django.conf import settings
 
-from resolwe.flow.models import Process
+from resolwe.flow.models import Data, Process
 from resolwe.flow.tasks import celery_run
+from resolwe.storage import settings as storage_settings
 from resolwe.utils import BraceMessage as __
 
 from .base import BaseConnector
@@ -34,7 +35,7 @@ if "sphinx" not in sys.modules:
 class Connector(BaseConnector):
     """Celery-based connector for job execution."""
 
-    def submit(self, data, runtime_dir, argv):
+    def submit(self, data: Data, argv):
         """Run process.
 
         For details, see
@@ -54,6 +55,7 @@ class Connector(BaseConnector):
                 getattr(settings, "CELERY_ALWAYS_EAGER", None),
             )
         )
+        runtime_dir = storage_settings.FLOW_VOLUMES["runtime"]["config"]["path"]
         celery_run.apply_async((data.id, runtime_dir, argv), queue=queue)
 
     def cleanup(self, data_id: int):

--- a/resolwe/flow/managers/workload_connectors/kubernetes.py
+++ b/resolwe/flow/managers/workload_connectors/kubernetes.py
@@ -760,7 +760,7 @@ class Connector(BaseConnector):
         """
         return "{}-{}".format(prefix, data_id)
 
-    def submit(self, data: Data, runtime_dir: str, argv: Any):
+    def submit(self, data: Data, argv):
         """Run process.
 
         For details, see

--- a/resolwe/flow/managers/workload_connectors/local.py
+++ b/resolwe/flow/managers/workload_connectors/local.py
@@ -8,6 +8,8 @@ Local Connector
 import logging
 import subprocess
 
+from resolwe.flow.models import Data
+from resolwe.storage import settings as storage_settings
 from resolwe.utils import BraceMessage as __
 
 from .base import BaseConnector
@@ -18,7 +20,7 @@ logger = logging.getLogger(__name__)
 class Connector(BaseConnector):
     """Local connector for job execution."""
 
-    def submit(self, data, runtime_dir, argv):
+    def submit(self, data: Data, argv):
         """Run process locally.
 
         For details, see
@@ -32,6 +34,7 @@ class Connector(BaseConnector):
                 repr(argv),
             )
         )
+        runtime_dir = storage_settings.FLOW_VOLUMES["runtime"]["config"]["path"]
         subprocess.Popen(argv, cwd=runtime_dir, stdin=subprocess.DEVNULL).wait()
 
     def cleanup(self, data_id: int):

--- a/resolwe/flow/managers/workload_connectors/slurm.py
+++ b/resolwe/flow/managers/workload_connectors/slurm.py
@@ -12,6 +12,8 @@ import subprocess
 
 from django.conf import settings
 
+from resolwe.flow.models import Data
+from resolwe.storage import settings as storage_settings
 from resolwe.utils import BraceMessage as __
 
 from .base import BaseConnector
@@ -26,7 +28,7 @@ EXECUTOR_MEMORY_OVERHEAD = 200
 class Connector(BaseConnector):
     """Slurm-based connector for job execution."""
 
-    def submit(self, data, runtime_dir, argv):
+    def submit(self, data: Data, argv):
         """Run process with SLURM.
 
         For details, see
@@ -49,6 +51,7 @@ class Connector(BaseConnector):
 
         try:
             # Make sure the resulting file is executable on creation.
+            runtime_dir = storage_settings.FLOW_VOLUMES["runtime"]["config"]["path"]
             script_path = os.path.join(runtime_dir, "slurm-{}.sh".format(data.pk))
             file_descriptor = os.open(script_path, os.O_WRONLY | os.O_CREAT, mode=0o555)
             with os.fdopen(file_descriptor, "wt") as script:


### PR DESCRIPTION
Then runtime volume can be removed from platform configuration entirely
when not needed, for instance when using Kubernetes workload manager.