### PR TITLE
Use the same connector to handle directories and files

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -23,6 +23,11 @@ Changed
 - Allow mounting connectors into pods as persistent volume claim instead of
   volume of type ``hostPath``
 
+Fixed
+-----
+- use the same connector inside pod to handle files and directories
+
+
 ===================
 28.5.0 - 2021-09-13
 ===================

--- a/resolwe/flow/executors/startup_communication_container.py
+++ b/resolwe/flow/executors/startup_communication_container.py
@@ -681,12 +681,8 @@ def set_default_storage_connectors():
     for storage_name, storage_settings in storages.items():
         storage_connectors = connectors.for_storage(storage_name)
         default_connector = storage_connectors[0]
-        default_mounted_connector = None
-        for connector in storage_connectors:
-            if connector.name in MOUNTED_CONNECTORS:
-                default_mounted_connector = connector
-                break
-
+        is_mountable = default_connector.name in MOUNTED_CONNECTORS
+        default_mounted_connector = default_connector if is_mountable else None
         STORAGE_CONNECTOR[storage_name] = (default_connector, default_mounted_connector)
 
 


### PR DESCRIPTION
When multiple connectors were defined and the default one was not
mountable, directories were handled by the mountable container and
files by the default one.