### PR TITLE
Do not fail in case of missing files in UriResolverView

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -6,6 +6,15 @@ All notable changes to this project are documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 
+==========
+Unreleased
+==========
+
+Changed
+-------
+- Do not fail in case of missing files in ``UriResolverView``
+
+
 ===================
 29.0.0 - 2021-11-11
 ===================
@@ -76,7 +85,7 @@ Fixed
 - Speed up deleting storage locations by considering only referenced paths
   belonging to the given storage location
 - Temporary pin ``asteval`` to version ``0.9.23`` due to compatibility issues
-  with Python 3.6 
+  with Python 3.6
 
 Changed
 -------

--- a/resolwe/storage/tests/test_views.py
+++ b/resolwe/storage/tests/test_views.py
@@ -2,6 +2,7 @@
 import json
 from unittest.mock import MagicMock, patch
 
+from django.core.exceptions import PermissionDenied
 from django.test import RequestFactory, TestCase
 
 from rest_framework import status
@@ -24,12 +25,15 @@ class UriResolverViewTest(TestCase):
             ("signed_url1", True),
             ("dir_structure", False),
             ("signed_url2", True),
+            PermissionDenied(),
         ]
 
         uris = [
+            "foo",
             "123/file1.txt",
             "456/dir",
             "789/dir/file2.txt",
+            "999/foo.txt",
         ]
         request = self.factory.post("", {"uris": uris}, content_type="application/json")
 
@@ -39,9 +43,11 @@ class UriResolverViewTest(TestCase):
         self.assertEqual(
             json.loads(response.content.decode("utf-8")),
             {
+                "foo": "",
                 "123/file1.txt": "signed_url1",
                 "456/dir": "dir_structure",
                 "789/dir/file2.txt": "signed_url2",
+                "999/foo.txt": "",
             },
         )
 

--- a/resolwe/storage/views.py
+++ b/resolwe/storage/views.py
@@ -255,7 +255,10 @@ class UriResolverView(DataBrowseView):
             data_id = int(match.group(1))
             relative_path = Path(match.group(2))
             datum = self._get_datum(data_id)
-            response_data[uri] = self._get_response(datum, relative_path)[0]
+            try:
+                response_data[uri] = self._get_response(datum, relative_path)[0]
+            except PermissionDenied:
+                response_data[uri] = ""
 
         return JsonResponse(response_data)
 


### PR DESCRIPTION
In UriResolverView, if a pre-signed url was requested for file that
does not exist (or user does not have permission for) an error is
raised. This happens even if only one out of 100 files is missing
or has permission denied.

From now on this is fixed: for failed urls, empty string is
returned and the response is still HTTP 200.