### PR TITLE
Fix: load kubertenes configuration every time

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -20,10 +20,6 @@ Changed
 -------
 - Retry loading ``Kubernetes`` configuration couple of times before giving up
   in the kubernetes workload connector
-- The ``Kubernetes`` configuration is loaded only once in the ``Kubernetes``
-  workload connector. This is possible due to the bug ignoring the
-  ``Kubernetes`` cluster ``API`` token expiration time being fixed in the
-  ``Kubernetes Python Client`` version ``v21.7.0``.
 
 
 ===================

--- a/resolwe/flow/managers/workload_connectors/kubernetes.py
+++ b/resolwe/flow/managers/workload_connectors/kubernetes.py
@@ -538,6 +538,12 @@ class Connector(BaseConnector):
 
         Construct kubernetes job description and pass it to the kubernetes.
         """
+        try:
+            self._load_kubernetes_config()
+        except kubernetes.config.config_exception.ConfigException as exception:
+            logger.exception("Could not load the kubernetes configuration.")
+            raise exception
+
         batch_api = kubernetes.client.BatchV1Api()
         core_api = kubernetes.client.CoreV1Api()
 
@@ -831,6 +837,12 @@ class Connector(BaseConnector):
 
     def cleanup(self, data_id: int):
         """Remove the persistent volume claims created by the executor."""
+        try:
+            self._load_kubernetes_config()
+        except kubernetes.config.config_exception.ConfigException as exception:
+            logger.exception("Could not load the kubernetes configuration.")
+            raise exception
+
         core_api = kubernetes.client.CoreV1Api()
         claim_names = [
             unique_volume_name(type_, data_id)


### PR DESCRIPTION
it seems the bug in kubernetes python client is not entirely fixed. Until issues with token refresh are entirely resolved the configuration has to be loaded every time