### PR TITLE
Add notify_created method on Subscription

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -14,6 +14,8 @@ Added
 -----
 - Add new entity annotation framework
 - Add set_permission method on PermissionQuerySet
+- Add notify_create method on Subscription model in observers to enable
+  sending notification when object is created
 
 
 ===================

--- a/resolwe/observers/models.py
+++ b/resolwe/observers/models.py
@@ -191,3 +191,18 @@ class Subscription(models.Model):
             async_to_sync(channel_layer.group_send)(channel, notification)
 
         transaction.on_commit(trigger)
+
+    def notify_created(self, content_type: ContentType):
+        """Send a create notification.
+
+        Used to send signal when models without permissions are created.
+        """
+        notification = {
+            "type": ChangeType.CREATE,
+            "content_type_pk": content_type.pk,
+            "change_type_value": ChangeType.CREATE.value,
+            "object_id": None,
+        }
+        channel_layer = get_channel_layer()
+        channel = GROUP_SESSIONS.format(session_id=self.session_id)
+        async_to_sync(channel_layer.group_send)(channel, notification)


### PR DESCRIPTION
to notify users when objects (without permissions) are created. The method must be called in order to send the signal.