### PR TITLE
Fix observer unsubscribe bug

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -26,6 +26,7 @@ Changed
 Fixed
 -----
 - Notify user when object (data, entity) is created in the container
+- Do not delete observers in use by other subscriptions when unsubscribing
 
 
 ===================

--- a/resolwe/observers/models.py
+++ b/resolwe/observers/models.py
@@ -167,7 +167,9 @@ class Subscription(models.Model):
         """
         # Find related observers with only one remaining subscription
         # (it must be this one) and delete them first.
-        self.observers.annotate(subs=Count("subscriptions")).filter(subs=1).delete()
+        Observer.objects.annotate(subs=Count("subscriptions")).filter(
+            subscriptions=self.pk, subs=1
+        ).delete()
         super().delete()
 
     @classmethod


### PR DESCRIPTION
Unsubscribing would sometimes delete observers belonging to other subscriptions.