### PR TITLE
Fix bug in superuser notification

### DIFF
--- a/resolwe/flow/views/mixins.py
+++ b/resolwe/flow/views/mixins.py
@@ -46,17 +46,13 @@ class ResolweCreateModelMixin(mixins.CreateModelMixin):
         """Create a resource."""
         with transaction.atomic():
             instance = serializer.save()
+            # Notify the users without explicit permissions (superusers).
+            post_permission_changed.send(sender=type(instance), instance=instance)
             if hasattr(instance, "permission_group"):
                 # Assign all permissions to the object contributor when object is not
                 # in container.
                 if not instance.in_container():
                     assign_contributor_permissions(instance)
-                # The object was created inheriting permissions from its container.
-                # Notify observers.
-                else:
-                    post_permission_changed.send(
-                        sender=type(instance), instance=instance
-                    )
 
 
 class ResolweUpdateModelMixin(mixins.UpdateModelMixin):

--- a/resolwe/observers/signals.py
+++ b/resolwe/observers/signals.py
@@ -58,6 +58,7 @@ def handle_permission_change(instance, **kwargs):
         losses = old - new
         Observer.observe_permission_changes(instance, gains, losses)
         observe_containers(instance)
+        instance._old_viewers = []
 
 
 @dispatch.receiver(model_signals.post_save)


### PR DESCRIPTION
superusers  were never notified when observable object permissions were changed since they always have all the permissions on every object.

The notifications are therefore sent to admins and regular users separately when object is created using the API.