### PR TITLE
Increase reset timeouts inside processing container

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -6,9 +6,9 @@ All notable changes to this project are documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 
-==========
-Unreleased
-==========
+===================
+35.0.0 - 2023-05-15
+===================
 
 Added
 -----

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -24,6 +24,7 @@ Changed
 - Bump ``Docker`` SDK version to fix requests/urllib incompatibility issue
   (<https://github.com/docker/docker-py/issues/3113>)
 - Always use ``Docker`` default seccomp profile
+- Increase resend timeout in processing container to 60 seconds
 
 
 ===================

--- a/resolwe/flow/executors/socket_utils.py
+++ b/resolwe/flow/executors/socket_utils.py
@@ -776,7 +776,7 @@ class BaseCommunicator:
         self,
         command: Message[MessageDataType],
         peer_identity: PeerIdentity = b"",
-        resend_timeout: Optional[int] = 30,
+        resend_timeout: Optional[int] = 60,
         timeout: Optional[int] = 1200,
     ) -> Response:
         """Send the command and return the response.


### PR DESCRIPTION
Some commands may take longer that 30 seconds to process. To avoid processing them twice increase the resend timeout to 60 seconds.

BUG-974