### PR TITLE
Use keys instead of scan_iter

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -28,6 +28,8 @@ Changed
 - Return ``False`` when ``has_perm`` is called with ``obj`` set no None, since
   object level permissions are granted using Django ``ModelBackend``
   authentication backend
+- Use ``keys`` instead of ``scan_iter`` in ``clear`` method of ``redis`` cache,
+  since ``scan_iter`` is much slower
 
 
 ===================

--- a/resolwe/flow/managers/listener/redis_cache.py
+++ b/resolwe/flow/managers/listener/redis_cache.py
@@ -323,7 +323,7 @@ class RedisCache:
         :raises RuntimeError: if identifiers are given without the content type.
         """
         key_prefix = f"{self._get_redis_key_prefix(Model, identifiers)}*"
-        redis_keys = list(self._redis.scan_iter(key_prefix))
+        redis_keys = self._redis.keys(key_prefix)
         if redis_keys:
             self._redis.unlink(*redis_keys)
 


### PR DESCRIPTION
to speed up cache clear in redis