### PR TITLE
Silently ignore nonexisting/without view permission objects when bulk deleting

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -6,6 +6,20 @@ All notable changes to this project are documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 
+==========
+Unreleased
+==========
+
+Fix
+---
+- Store refeneces to all subdirectories of the refenced files to the database
+
+Changed
+-------
+- Bulk delete method silently ignores non-existent objects and objects without
+  edit permissions instead of raising an exception
+
+
 ===================
 38.3.2 - 2024-01-25
 ===================

--- a/resolwe/flow/tests/test_api.py
+++ b/resolwe/flow/tests/test_api.py
@@ -935,7 +935,6 @@ class TestDataViewSetCase(TestCase):
         )
         force_authenticate(request, self.contributor)
         response = self.duplicate_viewset(request)
-        print("Got response", response.data)
         self.assertEqual(response.data["ids"], ["This list may not be empty."])
 
         request = factory.post(


### PR DESCRIPTION
REID-2208