### PR TITLE
Permission refresh

### DIFF
--- a/resolwe/flow/filters.py
+++ b/resolwe/flow/filters.py
@@ -28,7 +28,11 @@ from rest_framework import fields
 from rest_framework.filters import OrderingFilter as DrfOrderingFilter
 
 from resolwe.composer import composer
-from resolwe.permissions.models import Permission, get_anonymous_user
+from resolwe.permissions.models import (
+    Permission,
+    PermissionInterface,
+    get_anonymous_user,
+)
 
 from .models import (
     AnnotationField,
@@ -181,7 +185,9 @@ class UserFilterMixin:
         """Filter queryset by owner's name."""
         return queryset.filter(contributor__in=self._get_user_subquery(value))
 
-    def filter_for_user(self, queryset: QuerySet, name: str, value: str):
+    def filter_for_user(
+        self, queryset: QuerySet[PermissionInterface], name: str, value: str
+    ) -> QuerySet[PermissionInterface]:
         """Filter queryset by permissions."""
         user = self.request.user
         return queryset.filter_for_user(user, Permission.from_name(value))

--- a/resolwe/flow/managers/workload_connectors/kubernetes.py
+++ b/resolwe/flow/managers/workload_connectors/kubernetes.py
@@ -95,7 +95,7 @@ def sanitize_kubernetes_label(label: str, trim_end: bool = True) -> str:
     https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
     """
     max_length = 63
-    sanitized_label = re.sub("[^0-9a-zA-Z\-]+", "-", label).strip("-_.")
+    sanitized_label = re.sub(r"[^0-9a-zA-Z\-]+", "-", label).strip("-_.")
     if len(sanitized_label) > max_length:
         logger.warning(__("Label '%s' is too long and was truncated.", label))
         if trim_end:

--- a/resolwe/flow/models/storage.py
+++ b/resolwe/flow/models/storage.py
@@ -2,7 +2,7 @@
 
 from django.db import models
 
-from resolwe.permissions.models import PermissionQuerySet
+from resolwe.permissions.models import PermissionInterface, PermissionQuerySet
 
 from .base import BaseModel
 from .functions import JsonGetPath
@@ -38,7 +38,7 @@ class StorageManager(models.Manager):
         )
 
 
-class Storage(BaseModel):
+class Storage(BaseModel, PermissionInterface):
     """Postgres model for storing storages."""
 
     #: corresponding data objects
@@ -49,6 +49,11 @@ class Storage(BaseModel):
 
     #: storage manager
     objects = StorageManager.from_queryset(PermissionQuerySet)()
+
+    @classmethod
+    def permission_proxy(cls) -> str:
+        """Return the permission group path."""
+        return "data"
 
 
 class LazyStorageJSON:

--- a/resolwe/permissions/filters.py
+++ b/resolwe/permissions/filters.py
@@ -6,6 +6,8 @@ Permissions Filter
 
 """
 
+from django.db.models import QuerySet
+
 from rest_framework.filters import BaseFilterBackend
 from rest_framework.request import Request
 
@@ -16,14 +18,13 @@ from resolwe.permissions.utils import model_has_permissions
 class ResolwePermissionsFilter(BaseFilterBackend):
     """Permissions filter."""
 
-    def filter_queryset(
-        self, request: Request, queryset: PermissionQuerySet, view
-    ) -> PermissionQuerySet:
+    def filter_queryset(self, request: Request, queryset: QuerySet, view) -> QuerySet:
         """Filter permissions queryset.
 
         When model has no permission group defined return the entire queryset.
         """
         if model_has_permissions(queryset.model):
+            assert isinstance(queryset, PermissionQuerySet)
             queryset = queryset.filter_for_user(request.user)
 
         return queryset

--- a/resolwe/permissions/filters.py
+++ b/resolwe/permissions/filters.py
@@ -7,19 +7,23 @@ Permissions Filter
 """
 
 from rest_framework.filters import BaseFilterBackend
+from rest_framework.request import Request
 
+from resolwe.permissions.models import PermissionQuerySet
 from resolwe.permissions.utils import model_has_permissions
 
 
 class ResolwePermissionsFilter(BaseFilterBackend):
     """Permissions filter."""
 
-    def filter_queryset(self, request, queryset, view):
+    def filter_queryset(
+        self, request: Request, queryset: PermissionQuerySet, view
+    ) -> PermissionQuerySet:
         """Filter permissions queryset.
 
         When model has no permission group defined return the entire queryset.
         """
         if model_has_permissions(queryset.model):
-            return queryset.filter_for_user(request.user)
-        else:
-            return queryset
+            queryset = queryset.filter_for_user(request.user)
+
+        return queryset

--- a/resolwe/permissions/models.py
+++ b/resolwe/permissions/models.py
@@ -7,7 +7,7 @@ from typing import Iterable, List, Optional, Union
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group, User
+from django.contrib.auth.models import AnonymousUser, Group, User
 from django.db import models, transaction
 
 from resolwe.observers.protocol import post_permission_changed, pre_permission_changed
@@ -347,7 +347,7 @@ class PermissionQuerySet(models.QuerySet["PermissionInterface"]):
 
     def filter_for_user(
         self,
-        user: User,
+        user: User | AnonymousUser,
         permission: Permission = Permission.VIEW,
         use_groups: bool = True,
         public: bool = True,

--- a/resolwe/permissions/utils.py
+++ b/resolwe/permissions/utils.py
@@ -50,7 +50,7 @@ def set_permission(
     obj.set_permission(permission, user_or_group)
 
 
-def get_user(user: User) -> User:
+def get_user(user: User | AnonymousUser) -> User:
     """Get the same user or anonymous one when user is not authenticated.
 
     :raises django.core.exceptions.ObjectDoesNotExist: when user is not

--- a/resolwe/permissions/utils.py
+++ b/resolwe/permissions/utils.py
@@ -8,7 +8,7 @@ Permissions utils
 
 """
 
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple, Type, Union
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser, Group, User
@@ -18,6 +18,7 @@ from rest_framework import exceptions
 
 from resolwe.permissions.models import (
     Permission,
+    PermissionInterface,
     PermissionModel,
     UserOrGroup,
     get_anonymous_user,
@@ -61,10 +62,15 @@ def get_user(user: User) -> User:
         return get_anonymous_user()
 
 
-def model_has_permissions(obj: models.Model) -> bool:
+def model_has_permissions(obj: Union[models.Model, Type[models.Model]]) -> bool:
     """Check whether model has object level permissions."""
-    additional_labels = ["flow.Storage", "flow.AnnotationValue"]
-    return hasattr(obj, "permission_group") or obj._meta.label in additional_labels
+
+    try:
+        return isinstance(obj, PermissionInterface) or issubclass(
+            obj, PermissionInterface
+        )
+    except TypeError:
+        return False
 
 
 def get_identity(user_group: Union[Group, User]) -> Tuple[UserOrGroup, str]:

--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,7 @@ setuptools.setup(
             "daphne>=4.0.0",
             "django-stubs>=4.2.4",
             "djangorestframework-stubs[compatible-mypy]>=3.14.0",
+            "types-setuptools",
         ],
     },
     classifiers=[


### PR DESCRIPTION
Make it easier to add permissions to objects based on related objects with permissions.

For instance: the storage object is related to the data object so it can inherit the permissions from it.